### PR TITLE
feat(bugcheck): Shield PatchGuard-safe buffer + Anti-BSOD reference

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -5,6 +5,8 @@
 - [MSVC/WDK 构建恢复](ksword-build-recovery.md) — `LNK1000 IMAGE::BuildImage` 的一次性 WPO 禁用重建，以及驱动 x64 `ApiValidator` 后置校验边界
 - [驱动候选地址安全读取](ksword-driver-safe-read.md) — 不可信内核地址统一使用 `KswordARKRuntimeReadMemory`，以及 Release 同构函数符号归因注意事项
 - [蓝屏 BGP、截图基线与崩溃前解析缓存](ksword-bugcheck-bgp.md) — `BPP=1` 延迟探测、24/32 BPP 预生成、四区截图布局、进程/模块缓存、Stop Code 白名单归因与 fail-closed 边界
+- [蓝屏 Shield PatchGuard 安全缓冲](ksword-bugcheck-shield.md) — 只走公共 BugCheck reason 回调、多阶段有界 stall、KSHL 确认令牌、绝不写私有 ntoskrnl 状态
+- [Anti-BSOD 私有槽参考实现](ksword-bugcheck-antibsod.md) — 9-slot × 5-profile 签名扫描、栈来源分类、两个 hook、fail-closed 空签名边界；仅研究用途，默认编译开关关闭
 - [CI 合并回归恢复](ksword-ci-merge-recovery.md) — Actions 日志收敛顺序、共享 IOCTL 编号兼容、WDK 令牌声明与 `/WX` 协议头约束
 - [FileDock 文件元数据编辑](ksword-file-metadata-editor.md) — FILE_BASIC_INFO 零值写入、重解析点句柄、文件身份复核、结构性属性保留与异步回读
 - [Win32k 消息 Hook 筛选](ksword-message-hook-filtering.md) — 同侧原子筛选、目标/所有者 UI 范围、异步旧结果抑制、Hook 独立预算与诊断

--- a/.claude/memory/ksword-bugcheck-antibsod.md
+++ b/.claude/memory/ksword-bugcheck-antibsod.md
@@ -1,0 +1,173 @@
+# Anti-BSOD 参考实现（KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED）
+
+按 Anti-BSOD 报告的反编译在 KSword 里加了一份算法级参考实现。**这不是可
+上线的能力**：默认编译开关关闭，即使打开也依赖空签名表 fail-closed。用于
+研究、教学、以及作为其它蓝屏模块对照的稻草人。
+
+## 落点
+
+- 协议：`shared/driver/KswordArkBugcheckIoctl.h`
+  - `IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD`（function code `0x8FF`）
+  - 协议版本 `KSWORD_ARK_ANTIBSOD_PROTOCOL_VERSION = 1`
+  - 确认令牌 `KSWORD_ARK_ANTIBSOD_CONFIRMATION_TOKEN = 'KAKB' = 0x424B414B`
+  - 请求 `KSWORD_ARK_ANTIBSOD_REQUEST` / 响应 `KSWORD_ARK_ANTIBSOD_RESPONSE`
+- 头声明：`KswordARKDriver/include/ark/ark_bugcheck.h`
+  - `KswordARKAntiBsodInitialize/Uninitialize/IoctlConfigure`
+- 实现：`KswordARKDriver/src/features/bugcheck/bugcheck_antibsod.c`
+- 注册：`KswordARKDriver/src/dispatch/ioctl_registry.c`
+- 生命周期：`KswordARKDriver/src/framework/driver_entry.c`
+  - Initialize 在 Shield 之后调用；只准备同步原语和空签名表。
+  - Uninitialize 在 Shield 之后、Control 之前调用；调用 UninstallLocked。
+- 工程注册：`KswordARKDriver.vcxproj` 与 `.vcxproj.filters`
+  已同步加入 `Source Files\Features\Bugcheck`。
+
+## 编译开关
+
+`KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED`：
+
+- `0`（默认）：`Initialize/Uninitialize` 空操作，`IoctlConfigure` 返回
+  `STATUS_NOT_SUPPORTED`。整个模块除三个符号外不引入任何行为。
+- `1`：编译进完整实现。仍需 IOCTL 明确 INSTALL；未提供签名字节的情况下
+  Install 走 fail-closed 分支返回 `STATUS_OBJECT_NAME_NOT_FOUND`。
+
+Release 发行包默认使用 `0`。切换到 `1` 只用于研究环境。
+
+## 与报告的对照
+
+| 报告函数（Sample） | 参考实现 | 备注 |
+|---|---|---|
+| `FindWildcardBytePattern` | `KswordARKAntiBsodFindWildcardBytePattern` | 保留 0x00 通配符语义，额外校验 RangeEnd < RangeStart |
+| `ResolveRipRelativeTarget` | `KswordARKAntiBsodResolveRipRelativeTarget` | signed 32-bit 位移 |
+| `ReadUint32AtOffset` | `KswordARKAntiBsodReadUint32AtOffset` | Base=0 返回 0 |
+| `AddOffsetIfNonNull` | `KswordARKAntiBsodAddOffsetIfNonNull` | 同上 |
+| `SelectWindowsBuildProfile` | `KswordARKAntiBsodSelectWindowsBuildProfile` | 报告 5 段 build 区间；> 28000 时**拒绝**（样本继续） |
+| `FindLoadedModuleTextRange` | `KswordARKAntiBsodFindNtoskrnlTextRange` | ZwQuerySystemInformation 类 11，296 字节步长，PE 头 + section 遍历 |
+| `ClassifyBugcheckStackOrigin` | `KswordARKAntiBsodClassifyBugcheckStackOrigin` | RtlCaptureStackBackTrace 最多 64 帧，值 0/1/2 |
+| `CapturePerCpuBugcheckState` | `KswordARKAntiBsodCapturePerCpuBugcheckState` | KeGetPcr()->NtTib.FiberData (KPCR+0x20)、KPCR+SecondaryOffset |
+| `InstallBugcheckSuppressionHooks` | `KswordARKAntiBsodInstallLocked` | 9 级链式扫描 + fail-closed 校验 + IPI + 事件初始化 + SEH 写槽 |
+| `SuppressBugcheckAllProcessorsHook` | `KswordARKAntiBsodSuppressAllProcessorsHook` | 分类=0 转原函数；分类>0 改私有状态、遍历 CPU、legacy 分支 100ms 后再写、CR8=0、终态调 KTHREAD 私有槽或永久等待 |
+| `SuppressBugcheckCurrentProcessorHook` | `KswordARKAntiBsodSuppressCurrentProcessorHook` | 同上但只处理当前 CPU |
+| `KeWaitForSingleObject(&event, ..., NULL)` | `KswordARKAntiBsodWaitForever` | 无限循环 KeWaitForSingleObject |
+| DriverEntry-triggered install | 分离到 IOCTL | DriverEntry 只 Initialize；INSTALL 必须走 IOCTL |
+| （样本无 Unload） | `KswordARKAntiBsodUninstallLocked` | 恢复原槽 + 释放 per-CPU 数组，SEH 包住写回 |
+
+**参考实现相对样本增加的安全检查**（报告点名为样本"关键缺陷"）：
+
+- Install 结束前对 8 个解析结果统一非零校验，任一为 0 直接返回失败；
+- ZwQuerySystemInformation 双次调用之间校验 requiredBytes；
+- PE 头解析前分别校验 MZ 与 PE 签名；
+- OffsetToFileName 越界防御；
+- ActiveProcessorCount 越界防御（> 2048 拒绝）；
+- SEH 包住两个 hook 槽的写入并做失败回滚；
+- HookExecutions 计数器让 Uninstall 遇到"有 CPU 仍在 hook 里"时返回 BUSY；
+- 事件在 Install 完成后才 initialize，避免部分安装状态下被信号；
+- Legacy stall 参数 100000µs = 100ms，与样本一致。
+
+## 签名字节策略
+
+参考实现**不带**下面这些数据：
+
+- 五套 profile 的私有内核签名字节（每 slot 128 字节 × 9 slot × 5 profile）。
+- ntoskrnl 私有全局的精确写入值（`BugcheckStateFlagPtr` = 0、
+  `BugcheckInProgressFlagPtr` = 1、per-CPU 状态 = 0/1/5/34 这些常量已经
+  按报告保留，但对应的 offset 需要签名解析出来）。
+
+原因：报告作者也没有导出这些字节，KSword 也不导出。空签名 → `Length=0`
+→ 每级扫描返回 0 → fail-closed。要让它真跑起来的两个前置条件都必须由
+使用者自己完成：
+
+1. 在同一台目标机上（或结构完全一致的 PDB 匹配环境）反编译 `ntoskrnl`
+   得到 9 slot 的字节序列 + offset 参数；
+2. 通过外部工具填入 `g_KswordArkAntiBsodProfiles[N]`；这一步既不通过
+   IOCTL，也不通过磁盘文件——参考实现没有提供加载入口，任何"塞进去"
+   都要在源码里显式修改。
+
+## PatchGuard / HVCI 现实
+
+即便有人补齐了签名并成功装上 hook：
+
+- HVCI 打开时，`*(PVOID*)slot = ...` 走的是内核数据页，如果该私有槽本身
+  被 hypervisor 强制只读则 SEH 会捕获访问违例，Install 失败回滚。
+- PG 覆盖清单会周期扫描 `KiBugCheckOwner` 系列私有全局。虽然本模块没有
+  改这些字段的地址、而是改它们里面的 DWORD 值，但值改动同样会被 PG 的
+  内容抽样发现，触发 `0x109 CRITICAL_STRUCTURE_CORRUPTION`。
+- 抑制路径命中后 CPU 永远停在 `KeWaitForSingleObject`，机器实际上死机；
+  存储/DPC watchdog 后续会二次触发别的 bug check。
+
+上述失败模式**是设计而非缺陷**：这份实现只用来复现报告里的算法结构，
+不用来在生产内核上稳定运行。
+
+## R3 交互摘要
+
+- QUERY：无副作用，返回当前已发布的 state / mask / summary / lastStatus。
+- PROBE：只读跑一遍完整扫描管线（选 profile → 找 ntoskrnl `.text` →
+  9 级扫描），不装 hook、不分配 per-CPU。填充 `slotExpectedMask`、
+  `slotHitMask`、`supportSummary`。不需要确认令牌。
+- INSTALL：必须携带 `KAKB` 令牌 + `UI_CONFIRMED` flag，否则返回
+  `CONFIRMATION_NEEDED`。走完扫描后仍会发布 mask/summary，然后依赖
+  fail-closed 校验决定是否写槽。空签名下返回 `SIGNATURE_NOT_FOUND`。
+- UNINSTALL：正常时返回 `INACTIVE`；仍有 hook 在跑时返回 `BUSY`。
+
+## 透明化字段
+
+响应固定长度，永不返回原始内核指针。字段：
+
+- `stateFlags`：粗粒度状态位（`INSTALLED`、`HOOKS_ACTIVE`、
+  `LEGACY_BUILD`、`PROFILE_SELECTED`、`MODULE_RANGE_RESOLVED`、
+  `TARGETS_RESOLVED`、`PER_CPU_STATE_CAPTURED`、`SIGNATURES_EMPTY`）。
+- `windowsBuildNumber`、`selectedProfileIndex`、`kthreadRoutineOffset`：
+  当前系统身份与被选中的 build profile。
+- `slotExpectedMask`：9 位，第 N 位=1 表示 profile 第 N slot 的 `Length`
+  非零（即操作者已在源码里填入签名字节）。默认发行包全 0。
+- `slotHitMask`：9 位，第 N 位=1 表示第 N slot 扫描后解析到非零地址。
+- `supportSummary`：
+  - `UNKNOWN` 未跑过 PROBE/INSTALL；
+  - `UNSUPPORTED_BUILD` 当前 build 不在 5 段区间内；
+  - `SIGNATURES_EMPTY` build 支持但签名全空（默认发行包状态）；
+  - `PARTIAL_MATCH` 有签名但扫描漏掉部分；
+  - `FULL_MATCH` 每条 expected 规则都命中。
+
+Slot 索引（见 `KSWORD_ARK_ANTIBSOD_SLOT_*`）：
+
+| Bit | 名称 | 用途 | 类型 |
+|---|---|---|---|
+| 0 | `BUGCHECK_ANCHOR` | KeBugCheckEx 附近锚点 | ADD |
+| 1 | `BUGCHECK_CODE_START` | Bugcheck 私有代码区起点 | RIP |
+| 2 | `BUGCHECK_CODE_END` | Bugcheck 私有代码区终点 | ADD |
+| 3 | `STATE_FLAG_PTR` | 私有状态 DWORD 指针 | RIP |
+| 4 | `KPCR_STATE_OFFSET` | KPCR→PRCB state 偏移 | READ |
+| 5 | `KPCR_SECONDARY_OFFSET` | 二级 flag 偏移（可空） | READ |
+| 6 | `INPROGRESS_FLAG_PTR` | in-progress byte 指针 | RIP |
+| 7 | `ALL_HOOK_SLOT` | 全 CPU hook 槽 | RIP |
+| 8 | `CURRENT_HOOK_SLOT` | 当前 CPU hook 槽 | RIP |
+
+Slot 5 特殊：报告显示该字段在部分 build 上合法为 0；本实现在
+`Length == 0` 的情况下不把它标为 miss，避免整体报 PARTIAL_MATCH。
+
+## 与已有蓝屏模块的关系
+
+| 模块 | 用途 | 是否改私有内核 | 是否需要签名 |
+|---|---|---|---|
+| `bugcheck` (BGP) | 绘制蓝屏诊断页 | 否 | 否 |
+| `bugcheck_guard` | 一次性 KeBugCheckEx 延迟 | HVCI 关时补丁；开时用 callback | 否 |
+| `bugcheck_shield` | 多阶段有界缓冲窗口 | 否 | 否 |
+| `bugcheck_antibsod`（本条） | 私有槽 hook + 抑制 | **是**（当前模块唯一） | 是（外部提供） |
+
+只有 Anti-BSOD 参考属于"改私有内核 + 依赖签名"路径；生产发行包不启用。
+研究复现请在一次性 VM + 外部内核调试器 + 快照回滚的环境里操作，参考
+`.claude/memory/ksword-bugcheck-bgp.md` 里对目标机复测的说明。
+
+## 复测清单
+
+编译开关关闭时（默认）：
+- 加载驱动 → `IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD` 任何 action 返回
+  `STATUS_NOT_SUPPORTED`；registry 中该 IOCTL 存在但 handler 无副作用。
+
+编译开关开启但签名为空：
+- QUERY → `INACTIVE`，`SIGNATURES_EMPTY` 置位；
+- INSTALL（带令牌）→ `SIGNATURE_NOT_FOUND`；state 里 `PROFILE_SELECTED`
+  + `MODULE_RANGE_RESOLVED` 可置，`TARGETS_RESOLVED` 不置；
+- UNINSTALL → `INACTIVE`。
+
+编译开关开启并已由使用者补齐签名（不由 KSword 团队完成）：
+- 后果不在本模块承诺范围内；请参照报告和 PG/HVCI 部分的现实说明。

--- a/.claude/memory/ksword-bugcheck-shield.md
+++ b/.claude/memory/ksword-bugcheck-shield.md
@@ -1,0 +1,112 @@
+# 蓝屏缓冲 Shield（PatchGuard-safe）
+
+Bugcheck Shield 是 `bugcheck_guard.c` 之外的第二种缓冲后端。灵感来自公开逆向报告
+（例如 `Disable-PatchGuard-BSOD.sys`）：这些样本通过签名扫描私有 ntoskrnl 函数
+指针槽、写入自制 hook 并永久等待未置位事件来吞掉 bugcheck。该做法会触发
+PatchGuard/HVCI/WHQL 拒绝，且失败后系统处于不可恢复内核状态。Shield 只保留
+"扩大蓝屏与重启之间可观测窗口" 这个动机，实现仅使用公开 API。
+
+## 落点
+
+- 协议：`shared/driver/KswordArkBugcheckIoctl.h`
+  - `IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD`（function code `0x8FE`）
+  - 协议版本 `KSWORD_ARK_BUGCHECK_SHIELD_PROTOCOL_VERSION = 1`
+  - 确认令牌 `KSWORD_ARK_BUGCHECK_SHIELD_CONFIRMATION_TOKEN = 'KSHL' = 0x4C48534B`
+  - 请求 `KSWORD_ARK_BUGCHECK_SHIELD_REQUEST`、响应 `KSWORD_ARK_BUGCHECK_SHIELD_RESPONSE`
+  - 时间轴条目 `KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRY`，环容量 16
+- 头声明：`KswordARKDriver/include/ark/ark_bugcheck.h`
+  - `KswordARKBugcheckShieldInitialize/Uninitialize/IoctlConfigure`
+- 实现：`KswordARKDriver/src/features/bugcheck/bugcheck_shield.c`
+- 注册：`KswordARKDriver/src/dispatch/ioctl_registry.c`（前向声明 + 表项）
+- 生命周期：`KswordARKDriver/src/framework/driver_entry.c`
+  - Initialize：`KSWORD_ARK_BUGCHECK_DIAGNOSTICS_ENABLED` 分支内，`Guard` 之后
+  - Uninitialize：卸载路径，`Guard` 之后，`Control` 之前
+- 工程注册：`KswordARKDriver.vcxproj` 与 `.vcxproj.filters`
+  已同步加入 `Source Files\Features\Bugcheck`。
+
+## 安全边界
+
+- 仅使用公开 API：`KeRegisterBugCheckCallback` 与 `KeRegisterBugCheckReasonCallback`
+  （`KbCallbackSecondaryDumpData`、`KbCallbackDumpIo`、`KbCallbackAddPages`）。
+- 绝不修改 ntoskrnl 代码、私有函数指针槽、SSDT/IDT/GDT、CR0/CR4/CR8、MSR、
+  KPCR/KPRCB/KTHREAD 私有偏移，也不解析未文档化的 build-specific 结构。
+- 绝不永久等待任何事件；每个回调仅执行有界 `KeStallExecutionProcessor` 循环。
+- DriverEntry 只初始化同步原语；未收到 R3 IOCTL 前没有任何回调被注册。
+- 卸载与 DISABLE 都会先撤销 `Enabled` 再逐个 `KeDeregisterBugCheckCallback`/
+  `KeDeregisterBugCheckReasonCallback`，通过 `Executions` 计数器排空回调，
+  未排空则返回 `STATUS_DEVICE_BUSY`（`KSWORD_ARK_BUGCHECK_SHIELD_STATUS_BUSY`）。
+
+## 缓冲预算
+
+- 每回调阶段最大 `KSWORD_ARK_BUGCHECK_SHIELD_STAGE_MAX_SECONDS = 8` 秒。
+- 单次 ENABLE 全局总额最大 `KSWORD_ARK_BUGCHECK_SHIELD_TOTAL_MAX_SECONDS = 16` 秒。
+- 默认 stage 3 秒、total 10 秒。
+- 全局剩余毫秒由 `RemainingBudgetMs`（CAS 循环）跨回调共享，防止不同回调总
+  时长超过 total；无余额时该阶段直接跳过 stall，仍写入 timeline。
+- Stall 循环粒度 50µs，用 `KeQueryInterruptTime` 判定截止时间。
+
+## 时间轴
+
+- 环形数组 `Timeline[16]`，条目 `{reason, bugcheckCode, cpu, stalledMilliseconds}`。
+- `TimelineNextIndex` 由 `InterlockedIncrement` 分槽；超出容量的回调被丢弃但
+  仍完成 stall（防止 R3 观察到不匹配的分配）。
+- `TimelineCommittedCount` 只在字段写入完成后递增，读端据此确定可读前缀。
+- `bugcheckCode` 字段目前恒为 0：公共回调没有直接暴露 bug check code。字段保留
+  以便未来 kernel 暴露该值时可以扩展。
+
+## 请求校验
+
+- 版本、size 精确匹配当前协议。
+- 保留字段必须为 0；未来版本可安全扩展。
+- flags 只允许 `KSWORD_ARK_BUGCHECK_SHIELD_FLAG_UI_CONFIRMED`。
+- action：QUERY / ENABLE / DISABLE。
+- ENABLE 必须同时携带 `KSHL` 令牌与 UI_CONFIRMED 标志；否则返回
+  `CONFIRMATION_NEEDED`。
+- `reasonMask` 必须非零且不含 `~KSWORD_ARK_BUGCHECK_SHIELD_REASON_ALL`。
+- stage/total seconds：0 视为使用默认值；超过上限时钳制；stage > total 时
+  钳到 total。
+
+## 时间轴 reason 编码
+
+- `0x1` CLASSIC — `KeRegisterBugCheckCallback` 触发
+- `0x2` SECONDARY_DUMP_DATA — `KbCallbackSecondaryDumpData`
+- `0x4` DUMP_IO — `KbCallbackDumpIo`
+- `0x8` ADD_PAGES — `KbCallbackAddPages`
+- `0x0` 表示 kernel 触发了未订阅的 reason（记录进 timeline 用于诊断，不 stall）。
+
+## 与已有蓝屏模块的关系
+
+| 模块 | 用途 | 是否改私有内核 | 触发次数 |
+|---|---|---|---|
+| `bugcheck` (BGP/panel) | 绘制蓝屏诊断页 | 否，仅公开 BGP 加载期解析 | 每次崩溃 |
+| `bugcheck_guard` | 一次性 KeBugCheckEx 延迟 | HVCI 关时可直接补丁，HVCI 开时用 callback | 一次 |
+| `bugcheck_shield`（本条） | 多阶段有界缓冲窗口 | 否，仅公开 reason 回调 | 每次崩溃 |
+
+Guard 与 Shield 可以并存：Guard 关注 "延迟 KeBugCheckEx 本身"，Shield 关注
+"在标准 bugcheck 流程的多个阶段各留一段可观察窗口"。ENABLE 冲突由各自的
+`STATUS_ALREADY_REGISTERED` 语义保证。
+
+## 复测清单
+
+- `IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD` QUERY → 应返回 INACTIVE，
+  state=0，timeline 空。
+- ENABLE 缺 UI 确认或错误令牌 → `CONFIRMATION_NEEDED`，不注册任何回调。
+- ENABLE 合法 → `ACTIVE`，state 包含请求的 `*_REGISTERED` 位。
+- ENABLE 重复 → `STATUS_ALREADY_REGISTERED` 映射为 `ACTIVE`。
+- DISABLE → `INACTIVE`；如同一 CPU 上仍有回调在执行 → `BUSY`（应仅在人为
+  实验下出现，正常崩溃路径系统已不返回）。
+- 人为在测试机触发一次可控 bugcheck（例如 NotMyFault），返回 R3 后 QUERY 应
+  显示 `fireCount > 0`、`FIRED` 位为真，`timelineCount > 0`，条目 `reason`
+  值属于订阅集，`stalledMilliseconds` 各阶段和 ≤ totalSeconds*1000。
+
+## 边界与不做的事
+
+- 不承担蓝屏抑制：Shield 从不改变 bug check code、参数或返回路径，Windows
+  仍按正常流程写转储并重启。
+- 不承担 dump 数据写入：SecondaryDumpData/DumpIo/AddPages 回调不填充 OutBuffer；
+  如需向 dump 追加数据，另行走 `bugcheck` 模块的 SecondaryDumpData 通道。
+- 不做栈来源分类：报告样本用 `RtlCaptureStackBackTrace` 判断是否位于私有
+  bugcheck 代码区间以选择性抑制。这依赖未文档化的内核代码范围解析，Shield
+  故意不复刻。
+- 不做 IPI 采集每 CPU 状态：Shield 只关心当前回调 CPU，不去枚举其它 CPU 的
+  私有 KPCR/KPRCB 布局。

--- a/KswordARKDriver/KswordARKDriver.vcxproj
+++ b/KswordARKDriver/KswordARKDriver.vcxproj
@@ -152,6 +152,8 @@
     <ClCompile Include="src\features\bugcheck\bugcheck_svga.c" />
     <ClCompile Include="src\features\bugcheck\bugcheck_ioctl.c" />
     <ClCompile Include="src\features\bugcheck\bugcheck_guard.c" />
+    <ClCompile Include="src\features\bugcheck\bugcheck_shield.c" />
+    <ClCompile Include="src\features\bugcheck\bugcheck_antibsod.c" />
     <ClCompile Include="src\features\process\process_actions.c" />
     <ClCompile Include="src\features\process\process_crossview.c" />
     <ClCompile Include="src\features\process\process_detail.c" />

--- a/KswordARKDriver/KswordARKDriver.vcxproj.filters
+++ b/KswordARKDriver/KswordARKDriver.vcxproj.filters
@@ -788,6 +788,12 @@
     <ClCompile Include="src\features\bugcheck\bugcheck_guard.c">
       <Filter>Source Files\Features\Bugcheck</Filter>
     </ClCompile>
+    <ClCompile Include="src\features\bugcheck\bugcheck_shield.c">
+      <Filter>Source Files\Features\Bugcheck</Filter>
+    </ClCompile>
+    <ClCompile Include="src\features\bugcheck\bugcheck_antibsod.c">
+      <Filter>Source Files\Features\Bugcheck</Filter>
+    </ClCompile>
     <ClCompile Include="src\features\process\process_actions.c">
       <Filter>Source Files\Features</Filter>
     </ClCompile>

--- a/KswordARKDriver/include/ark/ark_bugcheck.h
+++ b/KswordARKDriver/include/ark/ark_bugcheck.h
@@ -115,5 +115,57 @@ KswordARKBugcheckGuardIoctlConfigure(
     _In_ size_t OutputBufferLength,
     _Out_ size_t* BytesReturned
     );
+
+// Bugcheck Shield is a PatchGuard-safe buffer backend. Unlike the guard, it
+// never patches KeBugCheckEx and never writes any private ntoskrnl state; it
+// only registers up to four documented BugCheck reason callbacks and stalls
+// each callback for a configurable, bounded window. Enabling and disabling
+// stay fully R3-controlled, and DriverEntry only prepares the synchronization
+// primitives — nothing observable happens until an IOCTL explicitly enables it.
+VOID
+KswordARKBugcheckShieldInitialize(
+    VOID
+    );
+
+VOID
+KswordARKBugcheckShieldUninitialize(
+    VOID
+    );
+
+NTSTATUS
+KswordARKBugcheckShieldIoctlConfigure(
+    _In_ WDFDEVICE Device,
+    _In_ WDFREQUEST Request,
+    _In_ size_t InputBufferLength,
+    _In_ size_t OutputBufferLength,
+    _Out_ size_t* BytesReturned
+    );
+
+// Anti-BSOD reference implementation. Behaviorally reproduces the algorithm
+// documented in the Disable-PatchGuard-BSOD.sys IDA analysis. The compile
+// flag KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED gates the entire module and
+// is OFF by default; when off, every entry point below is a no-op that
+// returns STATUS_NOT_SUPPORTED. When on, the module still ships with an
+// empty signature table so Install fails closed unless the operator adds
+// build-specific ntoskrnl patterns manually. This is deliberate: publishing
+// runnable private-slot signatures is outside the KSword scope.
+VOID
+KswordARKAntiBsodInitialize(
+    VOID
+    );
+
+VOID
+KswordARKAntiBsodUninitialize(
+    VOID
+    );
+
+NTSTATUS
+KswordARKAntiBsodIoctlConfigure(
+    _In_ WDFDEVICE Device,
+    _In_ WDFREQUEST Request,
+    _In_ size_t InputBufferLength,
+    _In_ size_t OutputBufferLength,
+    _Out_ size_t* BytesReturned
+    );
 EXTERN_C_END
 

--- a/KswordARKDriver/src/dispatch/ioctl_registry.c
+++ b/KswordARKDriver/src/dispatch/ioctl_registry.c
@@ -199,6 +199,8 @@ NTSTATUS KswordARKDebugOutputIoctlDrain(_In_ WDFDEVICE Device, _In_ WDFREQUEST R
 NTSTATUS KswordARKBugcheckIoctlSetBitmap(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKBugcheckIoctlSetVerdictResources(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKBugcheckGuardIoctlConfigure(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
+NTSTATUS KswordARKBugcheckShieldIoctlConfigure(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
+NTSTATUS KswordARKAntiBsodIoctlConfigure(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKRxpfIoctlQuerySupport(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKRxpfIoctlRegisterPage(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKRxpfIoctlChangePage(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
@@ -405,6 +407,10 @@ static const KSWORD_ARK_IOCTL_ENTRY g_KswordArkIoctlTable[] = {
     { IOCTL_KSWORD_ARK_SET_BUGCHECK_BITMAP, KswordARKBugcheckIoctlSetBitmap, "IOCTL_KSWORD_ARK_SET_BUGCHECK_BITMAP", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_QUIET_COMPLETION },
     { IOCTL_KSWORD_ARK_SET_BUGCHECK_VERDICT_RESOURCES, KswordARKBugcheckIoctlSetVerdictResources, "IOCTL_KSWORD_ARK_SET_BUGCHECK_VERDICT_RESOURCES", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_QUIET_COMPLETION },
     { IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_GUARD, KswordARKBugcheckGuardIoctlConfigure, "IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_GUARD", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
+    // Shield 只走公共 BugCheck 回调，绝不修改私有内核状态；enable 需要 UI 明确确认。
+    { IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD, KswordARKBugcheckShieldIoctlConfigure, "IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
+    // Anti-BSOD 参考实现：编译默认关闭，即使打开也依赖空签名表 fail-closed；只做研究用途。
+    { IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD, KswordARKAntiBsodIoctlConfigure, "IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
     // RXPF owns its exact-build, write-access, confirmation-token and safety-policy gates.
     { IOCTL_KSWORD_ARK_RXPF_QUERY_SUPPORT, KswordARKRxpfIoctlQuerySupport, "IOCTL_KSWORD_ARK_RXPF_QUERY_SUPPORT", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
     { IOCTL_KSWORD_ARK_RXPF_REGISTER_PAGE, KswordARKRxpfIoctlRegisterPage, "IOCTL_KSWORD_ARK_RXPF_REGISTER_PAGE", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },

--- a/KswordARKDriver/src/features/bugcheck/bugcheck_antibsod.c
+++ b/KswordARKDriver/src/features/bugcheck/bugcheck_antibsod.c
@@ -1,0 +1,1796 @@
+#include "ark/ark_driver.h"
+
+/*++
+
+Module Name:
+
+    bugcheck_antibsod.c
+
+Abstract:
+
+    Faithful, algorithm-level reproduction of the Disable-PatchGuard-BSOD.sys
+    sample described in the Anti-BSOD IDA analysis. This module exists so an
+    operator working from the same report can inspect, single-step, and
+    reason about the private-slot bugcheck-suppression pattern inside the
+    KSword codebase without having to load or trust the original binary.
+
+    What this file matches from the report
+    --------------------------------------
+
+      - Nine-slot, 0x4E0-byte per-build signature layout.
+      - Five build ranges with per-build KTHREAD routine offsets (912, 1528,
+        1104, 1248, 1248) and a legacy-build mode for pre-7602 systems.
+      - Wildcard byte scan where 0x00 in the pattern matches any target byte.
+      - RIP-relative displacement resolver.
+      - ntoskrnl `.text` range located through ZwQuerySystemInformation
+        SystemModuleInformation (class 11).
+      - Stack-origin classifier reading up to 64 return addresses through
+        RtlCaptureStackBackTrace and testing them against the resolved
+        bugcheck code range.
+      - Per-CPU KPCR/PRCB state capture broadcast by KeIpiGenericCall.
+      - Two suppression hooks that overwrite the resolved private
+        function-pointer slots, mutate private state, execute
+        __writecr8(0), optionally call an undocumented KTHREAD routine,
+        and permanently wait on a never-signaled NotificationEvent.
+
+    What this file deliberately does not do
+    ---------------------------------------
+
+      - No ntoskrnl private signature bytes are shipped. Every pattern is
+        zeroed with Length=0 so FindWildcardBytePattern returns 0 for
+        every scan. Every downstream resolver returns 0 for zero inputs
+        and Install fail-closes before touching a private slot. This is
+        the same policy the analysis report followed: the pattern layout
+        and offsets are public, the private kernel signature bytes are
+        deliberately not.
+      - The module is gated behind KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED
+        which defaults to 0. When 0, every entry point in this file is a
+        stub that returns STATUS_NOT_SUPPORTED. The shipping DriverEntry
+        never wires this module active without an explicit rebuild.
+      - Install adds the fail-closed pointer checks the analysis report
+        identifies as missing from the sample. When any resolver returns
+        0 the whole Install rolls back without writing any private slot.
+      - This file is x64-only, kernel-mode, and uses only kernel primitives
+        already imported by the KSword driver.
+
+Environment:
+
+    Kernel-mode Driver Framework
+
+--*/
+
+// The reference is x64-only. The KSword driver as a whole is x64-only,
+// but restating the gate here makes the file portable when copied.
+#if !defined(_WIN64)
+#error KSword Anti-BSOD reference only supports x64 builds.
+#endif
+
+// Build gate. Default OFF: when 0 the module compiles to stubs that
+// return STATUS_NOT_SUPPORTED and never touch kernel state. Turn on by
+// setting KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED=1 in the compiler command
+// line; note that turning it on without also filling in signatures still
+// results in fail-closed Install, which is the design intent.
+#ifndef KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED
+#define KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED 0
+#endif
+
+// Wire the shared confirmation token to a compile-time check so the driver
+// and any R3 caller cannot drift out of sync silently.
+C_ASSERT(KSWORD_ARK_ANTIBSOD_CONFIRMATION_TOKEN == 0x424B414BUL);
+
+#if !KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED
+
+// Disabled build: keep the exported symbols so ioctl_registry.c and
+// driver_entry.c can link, but return STATUS_NOT_SUPPORTED for every
+// live operation.
+VOID
+KswordARKAntiBsodInitialize(
+    VOID
+    )
+{
+    // No state to initialize when the reference is disabled at build time.
+}
+
+VOID
+KswordARKAntiBsodUninitialize(
+    VOID
+    )
+{
+    // Uninitialize is symmetric with Initialize: nothing to do when off.
+}
+
+NTSTATUS
+KswordARKAntiBsodIoctlConfigure(
+    _In_ WDFDEVICE Device,
+    _In_ WDFREQUEST Request,
+    _In_ size_t InputBufferLength,
+    _In_ size_t OutputBufferLength,
+    _Out_ size_t* BytesReturned
+    )
+{
+    // Explicitly acknowledge every parameter so /WX does not flag them.
+    UNREFERENCED_PARAMETER(Device);
+    UNREFERENCED_PARAMETER(Request);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    // Zero BytesReturned so callers see a deterministic short reply.
+    if (BytesReturned != NULL) {
+        *BytesReturned = 0U;
+    }
+    return STATUS_NOT_SUPPORTED;
+}
+
+#else
+
+// ============================================================================
+// Section 1: signature slot and profile layout
+// ============================================================================
+//
+// The Disable-PatchGuard-BSOD sample stores each build's signature set in
+// a fixed 0x4E0-byte record. Slots are pattern arrays followed by scanner
+// parameters. Three slot flavors exist:
+//
+//   ADD  = pattern + length + addOffset               (AddOffsetIfNonNull)
+//   RIP  = pattern + length + dispOffset + trailing   (ResolveRipRelativeTarget)
+//   READ = pattern + length + readOffset              (ReadUint32AtOffset)
+//
+// The composition is:
+//   +0x000 Slot0 ADD  bugcheck-code anchor
+//   +0x088 Slot1 RIP  bugcheck-code range start
+//   +0x114 Slot2 ADD  bugcheck-code range end
+//   +0x19C Slot3 RIP  private state DWORD pointer
+//   +0x228 Slot4 READ PRCB bug-check state offset
+//   +0x2B0 Slot5 READ KPCR secondary flag offset
+//   +0x338 Slot6 RIP  bug-check-in-progress byte pointer
+//   +0x3C4 Slot7 RIP  all-processors hook function slot
+//   +0x450 Slot8 RIP  current-processor hook function slot
+//   +0x4DC..0x4DF trailing padding
+//
+// All patterns are zeroed. Length=0 causes FindWildcardBytePattern to
+// return 0 for every scan; Install treats each 0 result as fatal.
+
+// ADD slot: 0x88 bytes total (128 pattern + 2 ULONG).
+typedef struct _KSWORD_ARK_ANTIBSOD_SIG_ADD
+{
+    UCHAR Pattern[128];
+    ULONG Length;
+    ULONG AddOffset;
+} KSWORD_ARK_ANTIBSOD_SIG_ADD;
+C_ASSERT(sizeof(KSWORD_ARK_ANTIBSOD_SIG_ADD) == 0x88);
+
+// RIP slot: 0x8C bytes total (128 pattern + 3 ULONG).
+typedef struct _KSWORD_ARK_ANTIBSOD_SIG_RIP
+{
+    UCHAR Pattern[128];
+    ULONG Length;
+    ULONG DispOffset;
+    ULONG TrailingAdjust;
+} KSWORD_ARK_ANTIBSOD_SIG_RIP;
+C_ASSERT(sizeof(KSWORD_ARK_ANTIBSOD_SIG_RIP) == 0x8C);
+
+// READ slot: 0x88 bytes total (128 pattern + 2 ULONG).
+typedef struct _KSWORD_ARK_ANTIBSOD_SIG_READ
+{
+    UCHAR Pattern[128];
+    ULONG Length;
+    ULONG ReadOffset;
+} KSWORD_ARK_ANTIBSOD_SIG_READ;
+C_ASSERT(sizeof(KSWORD_ARK_ANTIBSOD_SIG_READ) == 0x88);
+
+// Full profile record. Nine slots + 4 bytes trailing padding = 0x4E0.
+typedef struct _KSWORD_ARK_ANTIBSOD_PROFILE
+{
+    KSWORD_ARK_ANTIBSOD_SIG_ADD  Slot0BugcheckAnchor;
+    KSWORD_ARK_ANTIBSOD_SIG_RIP  Slot1BugcheckCodeStart;
+    KSWORD_ARK_ANTIBSOD_SIG_ADD  Slot2BugcheckCodeEnd;
+    KSWORD_ARK_ANTIBSOD_SIG_RIP  Slot3StateFlagPtr;
+    KSWORD_ARK_ANTIBSOD_SIG_READ Slot4KpcrStateOffset;
+    KSWORD_ARK_ANTIBSOD_SIG_READ Slot5KpcrSecondaryOffset;
+    KSWORD_ARK_ANTIBSOD_SIG_RIP  Slot6InProgressFlagPtr;
+    KSWORD_ARK_ANTIBSOD_SIG_RIP  Slot7AllProcessorsHookSlot;
+    KSWORD_ARK_ANTIBSOD_SIG_RIP  Slot8CurrentProcessorHookSlot;
+    UCHAR TrailingPadding[4];
+} KSWORD_ARK_ANTIBSOD_PROFILE;
+C_ASSERT(sizeof(KSWORD_ARK_ANTIBSOD_PROFILE) == 0x4E0);
+
+// Per-build metadata: build range, KTHREAD private routine offset, and
+// the "legacy" bit for pre-7602 systems. Numbers come from the report.
+typedef struct _KSWORD_ARK_ANTIBSOD_PROFILE_META
+{
+    ULONG MinBuild;
+    ULONG MaxBuild;
+    ULONG KthreadRoutineOffset;
+    BOOLEAN LegacyBuildMode;
+} KSWORD_ARK_ANTIBSOD_PROFILE_META;
+
+// Five profiles. Add or trim entries only alongside a matching update to
+// SelectWindowsBuildProfile.
+#define KSWORD_ARK_ANTIBSOD_PROFILE_COUNT 5UL
+
+static const KSWORD_ARK_ANTIBSOD_PROFILE_META
+    g_KswordArkAntiBsodProfileMeta[KSWORD_ARK_ANTIBSOD_PROFILE_COUNT] = {
+    {     0UL,  7601UL,  912UL, TRUE  }, // legacy Windows 7 / Server 2008 R2
+    {  7602UL,  9600UL, 1528UL, FALSE }, // Windows 8 / 8.1 / Server 2012 (R2)
+    {  9601UL, 20348UL, 1104UL, FALSE }, // Windows 10 through Server 2022
+    { 20349UL, 26200UL, 1248UL, FALSE }, // Windows 11 21H2 through 24H2 era
+    { 26201UL, 28000UL, 1248UL, FALSE }  // preview / Insider builds
+};
+
+// All-zero signature table. Filling in bytes here is the operator's own
+// step and is not shipped with the driver. The table lives in .data so
+// InstallSuppressionHooks can index it by the profile the OS build maps to.
+static KSWORD_ARK_ANTIBSOD_PROFILE
+    g_KswordArkAntiBsodProfiles[KSWORD_ARK_ANTIBSOD_PROFILE_COUNT];
+
+// ============================================================================
+// Section 2: SYSTEM_MODULE_INFORMATION mirror
+// ============================================================================
+//
+// The sample enumerates loaded modules through ZwQuerySystemInformation
+// class 11 (SystemModuleInformation) and walks the returned buffer with a
+// fixed 296-byte stride. That layout matches the classic RTL_PROCESS_MODULES
+// structure. We redeclare it locally so the file does not depend on
+// non-WDK headers.
+
+// A single module descriptor. Total size is 296 bytes.
+typedef struct _KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE
+{
+    HANDLE Section;           // +0x00
+    PVOID  MappedBase;        // +0x08
+    PVOID  ImageBase;         // +0x10
+    ULONG  ImageSize;         // +0x18
+    ULONG  Flags;             // +0x1C
+    USHORT LoadOrderIndex;    // +0x20
+    USHORT InitOrderIndex;    // +0x22
+    USHORT LoadCount;         // +0x24
+    USHORT OffsetToFileName;  // +0x26
+    UCHAR  FullPathName[256]; // +0x28..+0x127
+} KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE;
+C_ASSERT(sizeof(KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE) == 296);
+
+// Header + variable-length array.
+typedef struct _KSWORD_ARK_ANTIBSOD_MODULE_LIST
+{
+    ULONG NumberOfModules;
+    KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE Modules[1];
+} KSWORD_ARK_ANTIBSOD_MODULE_LIST;
+
+// ZwQuerySystemInformation prototype (already used by bugcheck_guard.c;
+// redeclared here so the file is self-contained).
+NTSYSAPI
+NTSTATUS
+NTAPI
+ZwQuerySystemInformation(
+    _In_ ULONG SystemInformationClass,
+    _Out_writes_bytes_opt_(SystemInformationLength) PVOID SystemInformation,
+    _In_ ULONG SystemInformationLength,
+    _Out_opt_ PULONG ReturnLength
+    );
+
+// The classic SYSTEM_INFORMATION_CLASS value for SystemModuleInformation.
+#define KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE_INFORMATION_CLASS 11UL
+
+// Pool tag used for the transient module-info allocation and per-CPU state
+// arrays. Distinct from every other bugcheck-family tag so kernel triage
+// pinpoints which module allocated a given block.
+#define KSWORD_ARK_ANTIBSOD_POOL_TAG 'sbAK' /* 'KAbs' little-endian */
+
+// ExAllocatePool2 is a Windows 10 20H1 addition. Older kernels do not
+// export it and the driver has to run on both. Match the repository-wide
+// convention: try to resolve ExAllocatePool2 dynamically, fall back to
+// ExAllocatePoolWithTag with pragma-suppressed 4996 so /WX still succeeds.
+typedef PVOID (NTAPI* KSWORD_ARK_ANTIBSOD_EX_ALLOCATE_POOL2_FN)(
+    POOL_FLAGS Flags,
+    SIZE_T NumberOfBytes,
+    ULONG Tag);
+
+static PVOID
+KswordARKAntiBsodAllocateNonPaged(
+    _In_ SIZE_T Bytes
+    )
+{
+    // Cache the resolved routine across calls. LONG guard covers the
+    // one-time resolve; subsequent callers hit the cached pointer.
+    static volatile LONG resolved = 0L;
+    static KSWORD_ARK_ANTIBSOD_EX_ALLOCATE_POOL2_FN allocatePool2 = NULL;
+    UNICODE_STRING routineName;
+
+    if (Bytes == 0U) {
+        return NULL;
+    }
+    if (InterlockedCompareExchange(&resolved, 1L, 0L) == 0L) {
+        RtlInitUnicodeString(&routineName, L"ExAllocatePool2");
+        allocatePool2 = (KSWORD_ARK_ANTIBSOD_EX_ALLOCATE_POOL2_FN)
+            MmGetSystemRoutineAddress(&routineName);
+    }
+    if (allocatePool2 != NULL) {
+        // Modern path: NX non-paged pool through the documented flag API.
+        return allocatePool2(
+            POOL_FLAG_NON_PAGED,
+            Bytes,
+            KSWORD_ARK_ANTIBSOD_POOL_TAG);
+    }
+#pragma warning(push)
+#pragma warning(disable:4996)
+    // Legacy path: NonPagedPoolNx is the closest equivalent on down-level
+    // Windows and the same choice the rest of the driver uses.
+    return ExAllocatePoolWithTag(
+        NonPagedPoolNx,
+        Bytes,
+        KSWORD_ARK_ANTIBSOD_POOL_TAG);
+#pragma warning(pop)
+}
+
+// ============================================================================
+// Section 3: runtime state
+// ============================================================================
+
+// KEVENT initializer type sentinel: NotificationEvent maps to 0 in the
+// documented header, but we spell it out to keep the source explicit.
+#define KSWORD_ARK_ANTIBSOD_EVENT_KIND NotificationEvent
+
+typedef struct _KSWORD_ARK_ANTIBSOD_STATE
+{
+    // Serializes install/uninstall/query at PASSIVE_LEVEL. Callback code
+    // never touches this lock: bugcheck path can run at HIGH_LEVEL where
+    // FAST_MUTEX would deadlock.
+    FAST_MUTEX ControlLock;
+
+    // Set to 1 once InstallSuppressionHooks completes. Uninstall clears it.
+    volatile LONG Installed;
+    // Set to 1 once both hooks are live and the never-signaled event has
+    // been initialized. Different from Installed so a partial install can
+    // be observed by R3 for diagnostics.
+    volatile LONG HooksActive;
+    // Nesting counter incremented on hook entry and decremented on exit.
+    // Uninstall refuses to release resources while this is nonzero.
+    volatile LONG HookExecutions;
+    // Bumped once per hook entry, never decremented. Reported to R3.
+    volatile LONG HookInvocationCount;
+
+    // Snapshot of the selected profile identity for diagnostics.
+    ULONG WindowsBuildNumber;
+    ULONG SelectedProfileIndex;
+    ULONG KthreadRoutineOffset;
+    BOOLEAN LegacyBuildMode;
+
+    // Pointer to the selected profile inside g_KswordArkAntiBsodProfiles.
+    const KSWORD_ARK_ANTIBSOD_PROFILE* Profile;
+
+    // Resolved ntoskrnl module range and KeBugCheckEx anchor.
+    ULONG_PTR NtTextStart;
+    ULONG_PTR NtTextEnd;
+    ULONG_PTR KeBugCheckExAddress;
+
+    // Resolved private targets. Every one of these fields must be nonzero
+    // before Install commits: this is the fail-closed check the analysis
+    // report identifies as missing from the original sample.
+    ULONG_PTR BugcheckScanBoundary;
+    ULONG_PTR BugcheckCodeRangeStart;
+    ULONG_PTR BugcheckCodeRangeEnd;
+    ULONG_PTR BugcheckStateFlagPtr;
+    ULONG     KpcrBugcheckStateOffset;
+    ULONG     KpcrSecondaryFlagOffset;
+    ULONG_PTR BugcheckInProgressFlagPtr;
+    ULONG_PTR AllProcessorsHookSlot;
+    ULONG_PTR CurrentProcessorHookSlot;
+
+    // Function pointers we saved from the two hook slots before overwriting.
+    PVOID OriginalAllProcessorsRoutine;
+    PVOID OriginalCurrentProcessorRoutine;
+
+    // Transparency masks published to R3. Bit N corresponds to slot N.
+    //   SlotExpectedMask: profile has a nonzero pattern length for slot N.
+    //   SlotHitMask: scan for slot N produced a nonzero resolved value.
+    // Both are only meaningful after Install or Probe has run.
+    volatile LONG SlotExpectedMask;
+    volatile LONG SlotHitMask;
+    // SupportSummary value from the shared header. Reset to UNKNOWN by
+    // Uninitialize, updated by Install or Probe.
+    volatile LONG SupportSummary;
+
+    // Per-CPU state captured by the IPI broadcast.
+    ULONG ActiveProcessorCount;
+    ULONG_PTR* PerCpuPrcbArray;
+    ULONG_PTR* PerCpuSecondaryStateArray;
+
+    // Notification event that is created but never signaled. The hooks
+    // wait on it forever. The analysis report identifies this as the
+    // "permanent wait" that keeps the crashing CPU inside the driver.
+    KEVENT NeverSignaledEvent;
+
+    // Last kernel status surfaced to R3 for diagnostics.
+    NTSTATUS LastStatus;
+} KSWORD_ARK_ANTIBSOD_STATE;
+
+// Single global state. The sample is not per-device; the reference matches.
+static KSWORD_ARK_ANTIBSOD_STATE g_KswordArkAntiBsod;
+
+// Forward declarations for the two suppression hooks. Signatures match
+// the sample's __fastcall four-argument prototype so the resolved slot
+// can be replaced without an intermediate trampoline.
+typedef __int64 (__fastcall* KSWORD_ARK_ANTIBSOD_HOOK_FN)(
+    __int64 arg1,
+    __int64 arg2,
+    __int64 arg3,
+    __int64 arg4
+    );
+
+static __int64 __fastcall
+KswordARKAntiBsodSuppressAllProcessorsHook(
+    __int64 arg1,
+    __int64 arg2,
+    __int64 arg3,
+    __int64 arg4
+    );
+
+static __int64 __fastcall
+KswordARKAntiBsodSuppressCurrentProcessorHook(
+    __int64 arg1,
+    __int64 arg2,
+    __int64 arg3,
+    __int64 arg4
+    );
+
+// ============================================================================
+// Section 4: scanning helpers (four pure functions from the report)
+// ============================================================================
+
+// FindWildcardBytePattern: linear scan across [RangeStart, RangeEnd) for a
+// pattern whose 0x00 bytes are wildcards. Returns 0 when the pattern is
+// empty, the length is zero, or the pattern is not found.
+static ULONG_PTR
+KswordARKAntiBsodFindWildcardBytePattern(
+    _In_ ULONG_PTR RangeStart,
+    _In_reads_bytes_opt_(PatternLength) const UCHAR* Pattern,
+    _In_ ULONG_PTR RangeEnd,
+    _In_ SIZE_T PatternLength
+    )
+{
+    SIZE_T candidateOffset;
+    SIZE_T patternIndex;
+    SIZE_T spanBytes;
+    UCHAR expected;
+    UCHAR actual;
+
+    // Guard against the two edge cases the sample also rejects up front.
+    if (Pattern == NULL || PatternLength == 0) {
+        return 0;
+    }
+    // Guard against RangeEnd < RangeStart to avoid an underflow when the
+    // caller passed a bogus interval; the sample did not do this.
+    if (RangeEnd < RangeStart) {
+        return 0;
+    }
+    // Compute how many candidate positions exist. If the pattern is longer
+    // than the range there is nothing to scan.
+    spanBytes = (SIZE_T)(RangeEnd - RangeStart);
+    if (spanBytes < PatternLength) {
+        return 0;
+    }
+    // The sample iterates from 0 to spanBytes - PatternLength inclusive.
+    for (candidateOffset = 0;
+         candidateOffset <= spanBytes - PatternLength;
+         ++candidateOffset) {
+        // Test each byte, treating 0x00 in the pattern as a wildcard.
+        for (patternIndex = 0; patternIndex < PatternLength; ++patternIndex) {
+            expected = Pattern[patternIndex];
+            actual = *(const UCHAR*)(RangeStart + patternIndex + candidateOffset);
+            if (expected != 0 && actual != expected) {
+                break;
+            }
+        }
+        if (patternIndex == PatternLength) {
+            return RangeStart + candidateOffset;
+        }
+    }
+    return 0;
+}
+
+// ResolveRipRelativeTarget: given an instruction address and the byte
+// offsets that identify the rel32 displacement field, resolve the absolute
+// target of a x64 RIP-relative reference.
+static ULONG_PTR
+KswordARKAntiBsodResolveRipRelativeTarget(
+    _In_ ULONG_PTR Instruction,
+    _In_ ULONG DisplacementOffset,
+    _In_ ULONG TrailingAdjustment
+    )
+{
+    LONG displacement;
+
+    // Sample returns 0 for a null instruction pointer, so do the same.
+    if (Instruction == 0) {
+        return 0;
+    }
+    // Signed 32-bit displacement stored at Instruction + DisplacementOffset.
+    displacement = *(const LONG*)(Instruction + DisplacementOffset);
+    // Absolute target = start of displacement + 4 (rel32 width) + trailing.
+    return Instruction + DisplacementOffset + 4UL +
+        TrailingAdjustment + (ULONG_PTR)(LONG_PTR)displacement;
+}
+
+// ReadUint32AtOffset: read a ULONG at Base + Offset when Base is nonzero.
+// Used to extract KPCR/PRCB byte offsets encoded as immediates in a mov.
+static ULONG
+KswordARKAntiBsodReadUint32AtOffset(
+    _In_ ULONG_PTR Base,
+    _In_ ULONG Offset
+    )
+{
+    if (Base == 0) {
+        return 0;
+    }
+    return *(const ULONG*)(Base + Offset);
+}
+
+// AddOffsetIfNonNull: add Offset to Base when Base is nonzero.
+static ULONG_PTR
+KswordARKAntiBsodAddOffsetIfNonNull(
+    _In_ ULONG_PTR Base,
+    _In_ ULONG Offset
+    )
+{
+    if (Base == 0) {
+        return 0;
+    }
+    return Base + Offset;
+}
+
+// ============================================================================
+// Section 5: Windows build profile selection
+// ============================================================================
+
+// SelectWindowsBuildProfile: read the current build number and pick the
+// matching entry in g_KswordArkAntiBsodProfiles. Returns TRUE when a
+// profile is selected. Unlike the sample, this refuses to continue when
+// the build number is above every declared range.
+static BOOLEAN
+KswordARKAntiBsodSelectWindowsBuildProfile(VOID)
+{
+    RTL_OSVERSIONINFOW version;
+    NTSTATUS status;
+    ULONG i;
+
+    // Zero the version struct so RtlGetVersion sees a fresh input.
+    RtlZeroMemory(&version, sizeof(version));
+    version.dwOSVersionInfoSize = sizeof(version);
+    status = RtlGetVersion(&version);
+    if (!NT_SUCCESS(status)) {
+        // Sample ignored this; the reference records and bails.
+        g_KswordArkAntiBsod.LastStatus = status;
+        return FALSE;
+    }
+    g_KswordArkAntiBsod.WindowsBuildNumber = version.dwBuildNumber;
+    // Walk the metadata table looking for a match. Ranges are inclusive.
+    for (i = 0; i < KSWORD_ARK_ANTIBSOD_PROFILE_COUNT; ++i) {
+        if (version.dwBuildNumber >=
+                g_KswordArkAntiBsodProfileMeta[i].MinBuild &&
+            version.dwBuildNumber <=
+                g_KswordArkAntiBsodProfileMeta[i].MaxBuild) {
+            g_KswordArkAntiBsod.SelectedProfileIndex = i;
+            g_KswordArkAntiBsod.KthreadRoutineOffset =
+                g_KswordArkAntiBsodProfileMeta[i].KthreadRoutineOffset;
+            g_KswordArkAntiBsod.LegacyBuildMode =
+                g_KswordArkAntiBsodProfileMeta[i].LegacyBuildMode;
+            g_KswordArkAntiBsod.Profile =
+                &g_KswordArkAntiBsodProfiles[i];
+            return TRUE;
+        }
+    }
+    // No match: the sample fell through with a NULL profile; the reference
+    // stops here so downstream resolvers do not dereference a null pointer.
+    g_KswordArkAntiBsod.LastStatus = STATUS_NOT_SUPPORTED;
+    return FALSE;
+}
+
+// ============================================================================
+// Section 6: ntoskrnl .text range resolution
+// ============================================================================
+
+// FindLoadedModuleTextRange: resolve ntoskrnl.exe's .text bounds through
+// ZwQuerySystemInformation. Returns TRUE only when the section is located
+// and both endpoints are populated in the state struct.
+static BOOLEAN
+KswordARKAntiBsodFindNtoskrnlTextRange(VOID)
+{
+    // The routine name string is fixed at kernel-mode load time and does
+    // not change across boots. Declared as a const-initialized buffer so
+    // no runtime allocation is required.
+    static const CHAR NtoskrnlName[] = "ntoskrnl.exe";
+    static const CHAR TextSectionName[] = ".text";
+    ULONG requiredBytes = 0UL;
+    NTSTATUS status;
+    PVOID moduleBuffer = NULL;
+    KSWORD_ARK_ANTIBSOD_MODULE_LIST* list = NULL;
+    KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE* entry = NULL;
+    ULONG moduleIndex;
+    const CHAR* baseName;
+    PVOID imageBase;
+    ULONG_PTR ntHeaders;
+    ULONG_PTR sectionTable;
+    ULONG sectionIndex;
+    ULONG sectionCount;
+    BOOLEAN success = FALSE;
+
+    // First call: size query. Windows returns STATUS_INFO_LENGTH_MISMATCH
+    // and the required buffer size through the last parameter.
+    status = ZwQuerySystemInformation(
+        KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE_INFORMATION_CLASS,
+        NULL,
+        0UL,
+        &requiredBytes);
+    if (requiredBytes == 0UL) {
+        // Sample skipped this check; the reference bails out cleanly.
+        g_KswordArkAntiBsod.LastStatus = status;
+        return FALSE;
+    }
+    // Allocate a non-paged buffer big enough for the full list. Reserve a
+    // little slack in case the module count grows between calls.
+    moduleBuffer = KswordARKAntiBsodAllocateNonPaged(
+        (SIZE_T)requiredBytes + 4096U);
+    if (moduleBuffer == NULL) {
+        g_KswordArkAntiBsod.LastStatus = STATUS_INSUFFICIENT_RESOURCES;
+        return FALSE;
+    }
+    // Second call: actually populate the buffer.
+    status = ZwQuerySystemInformation(
+        KSWORD_ARK_ANTIBSOD_SYSTEM_MODULE_INFORMATION_CLASS,
+        moduleBuffer,
+        requiredBytes + 4096UL,
+        &requiredBytes);
+    if (!NT_SUCCESS(status)) {
+        g_KswordArkAntiBsod.LastStatus = status;
+        ExFreePoolWithTag(moduleBuffer, KSWORD_ARK_ANTIBSOD_POOL_TAG);
+        return FALSE;
+    }
+    list = (KSWORD_ARK_ANTIBSOD_MODULE_LIST*)moduleBuffer;
+    // Walk entries looking for a matching basename. The kernel writes the
+    // basename inside FullPathName at OffsetToFileName.
+    for (moduleIndex = 0; moduleIndex < list->NumberOfModules; ++moduleIndex) {
+        entry = &list->Modules[moduleIndex];
+        // Guard OffsetToFileName so a malformed entry cannot walk past the
+        // module's own buffer.
+        if (entry->OffsetToFileName >= sizeof(entry->FullPathName)) {
+            continue;
+        }
+        baseName = (const CHAR*)&entry->FullPathName[entry->OffsetToFileName];
+        // Case-insensitive compare; ntoskrnl.exe on disk is lowercase but
+        // the kernel path can vary in case across builds.
+        if (_stricmp(baseName, NtoskrnlName) != 0) {
+            continue;
+        }
+        imageBase = entry->ImageBase;
+        if (imageBase == NULL) {
+            break;
+        }
+        // Validate the DOS header magic before touching e_lfanew.
+        if (*(const USHORT*)imageBase != IMAGE_DOS_SIGNATURE) {
+            break;
+        }
+        ntHeaders = (ULONG_PTR)imageBase +
+            ((const IMAGE_DOS_HEADER*)imageBase)->e_lfanew;
+        // Validate the PE signature before touching FileHeader.
+        if (*(const ULONG*)ntHeaders != IMAGE_NT_SIGNATURE) {
+            break;
+        }
+        sectionCount =
+            ((const IMAGE_NT_HEADERS64*)ntHeaders)->FileHeader.NumberOfSections;
+        sectionTable = ntHeaders +
+            FIELD_OFFSET(IMAGE_NT_HEADERS64, OptionalHeader) +
+            ((const IMAGE_NT_HEADERS64*)ntHeaders)->
+                FileHeader.SizeOfOptionalHeader;
+        for (sectionIndex = 0; sectionIndex < sectionCount; ++sectionIndex) {
+            const IMAGE_SECTION_HEADER* section =
+                (const IMAGE_SECTION_HEADER*)
+                    (sectionTable + sectionIndex * sizeof(IMAGE_SECTION_HEADER));
+            // Sample compared the first five bytes of the section name;
+            // do the same so we accept ".text" and reject anything else.
+            if (RtlCompareMemory(
+                    section->Name,
+                    TextSectionName,
+                    sizeof(TextSectionName) - 1U) == sizeof(TextSectionName) - 1U) {
+                g_KswordArkAntiBsod.NtTextStart =
+                    (ULONG_PTR)imageBase + section->VirtualAddress;
+                g_KswordArkAntiBsod.NtTextEnd =
+                    g_KswordArkAntiBsod.NtTextStart + section->Misc.VirtualSize;
+                success = TRUE;
+                break;
+            }
+        }
+        break;
+    }
+    ExFreePoolWithTag(moduleBuffer, KSWORD_ARK_ANTIBSOD_POOL_TAG);
+    if (!success) {
+        g_KswordArkAntiBsod.LastStatus = STATUS_NOT_FOUND;
+    }
+    return success;
+}
+
+// ============================================================================
+// Section 7: per-CPU state capture (IPI callback)
+// ============================================================================
+
+// Broadcast callback invoked on every active processor. Reads the KPCR
+// derived state pointers the sample stores in two parallel arrays.
+static ULONG_PTR
+KswordARKAntiBsodCapturePerCpuBugcheckState(
+    _In_ ULONG_PTR IgnoredArgument
+    )
+{
+    ULONG cpuIndex;
+    ULONG_PTR kpcr;
+
+    UNREFERENCED_PARAMETER(IgnoredArgument);
+    // Determine the executing CPU index. KeGetCurrentProcessorNumberEx
+    // is documented callable at any IRQL, including HIGH_LEVEL.
+    cpuIndex = KeGetCurrentProcessorNumberEx(NULL);
+    // The KPCR self-pointer is exposed through KeGetPcr on x64. Even
+    // though the sample read gs:[0x18] directly, the effect is identical.
+    kpcr = (ULONG_PTR)KeGetPcr();
+    // Guard against a null result before writing arrays; the sample did
+    // not check but the reference does so a corrupt system does not
+    // amplify into a per-CPU array overrun.
+    if (g_KswordArkAntiBsod.PerCpuPrcbArray != NULL) {
+        // Sample stored KPCR + 0x20 (NtTib.FiberData). Match that offset.
+        g_KswordArkAntiBsod.PerCpuPrcbArray[cpuIndex] =
+            *(ULONG_PTR*)(kpcr + 0x20);
+    }
+    if (g_KswordArkAntiBsod.PerCpuSecondaryStateArray != NULL) {
+        // Sample stored KPCR + KpcrSecondaryFlagOffset as an address.
+        g_KswordArkAntiBsod.PerCpuSecondaryStateArray[cpuIndex] =
+            kpcr + g_KswordArkAntiBsod.KpcrSecondaryFlagOffset;
+    }
+    return 0;
+}
+
+// ============================================================================
+// Section 8: stack-origin classification
+// ============================================================================
+
+// StackClass values match the sample: 0 = no frame lies in the bug-check
+// code range, 1 = a frame is present with a captured continuation slot,
+// 2 = a frame is present at the terminal boundary.
+#define KSWORD_ARK_ANTIBSOD_STACK_NO_TARGET_FRAME      0
+#define KSWORD_ARK_ANTIBSOD_STACK_WITH_CONTINUATION    1
+#define KSWORD_ARK_ANTIBSOD_STACK_TERMINAL_BOUNDARY    2
+
+// Buffer size for CaptureStackBackTrace. Sample used 64 frames.
+#define KSWORD_ARK_ANTIBSOD_STACK_FRAME_COUNT 64
+
+static ULONG
+KswordARKAntiBsodClassifyBugcheckStackOrigin(VOID)
+{
+    PVOID frames[KSWORD_ARK_ANTIBSOD_STACK_FRAME_COUNT];
+    ULONG captured;
+    ULONG frameIndex;
+    ULONG_PTR frameAddress;
+
+    // Sample zeroes the buffer before the call; do the same so an early
+    // exit does not observe stack garbage.
+    RtlZeroMemory(frames, sizeof(frames));
+    captured = RtlCaptureStackBackTrace(
+        0UL,
+        KSWORD_ARK_ANTIBSOD_STACK_FRAME_COUNT,
+        frames,
+        NULL);
+    // Iterate the captured slots. A null slot marks the end of the trace.
+    for (frameIndex = 0;
+         frameIndex < KSWORD_ARK_ANTIBSOD_STACK_FRAME_COUNT;
+         ++frameIndex) {
+        if (frameIndex >= captured || frames[frameIndex] == NULL) {
+            return KSWORD_ARK_ANTIBSOD_STACK_NO_TARGET_FRAME;
+        }
+        frameAddress = (ULONG_PTR)frames[frameIndex];
+        if (frameAddress >= g_KswordArkAntiBsod.BugcheckCodeRangeStart &&
+            frameAddress <= g_KswordArkAntiBsod.BugcheckCodeRangeEnd) {
+            // A frame lies inside the resolved bug-check code range.
+            // The sample distinguishes terminal-boundary from continuation
+            // by whether the next captured slot is nonzero.
+            if (frameIndex + 1UL < captured &&
+                frames[frameIndex + 1UL] != NULL) {
+                return KSWORD_ARK_ANTIBSOD_STACK_WITH_CONTINUATION;
+            }
+            return KSWORD_ARK_ANTIBSOD_STACK_TERMINAL_BOUNDARY;
+        }
+    }
+    return KSWORD_ARK_ANTIBSOD_STACK_NO_TARGET_FRAME;
+}
+
+// ============================================================================
+// Section 9: the two suppression hooks
+// ============================================================================
+
+// Waits forever on a NotificationEvent that is created but never signaled.
+// The analysis report notes this is the point where the sample's design
+// requires the crashing CPU to never return.
+static VOID
+KswordARKAntiBsodWaitForever(VOID)
+{
+    // Bounded loop is intentional: the sample loops so a spurious wake
+    // (never expected in practice) does not fall through to the caller.
+    while (TRUE) {
+        (VOID)KeWaitForSingleObject(
+            &g_KswordArkAntiBsod.NeverSignaledEvent,
+            Executive,
+            KernelMode,
+            FALSE,
+            NULL);
+    }
+}
+
+// Invoke the KTHREAD private routine slot the sample transfers to at the
+// terminal-boundary stack classification. We do not return from this.
+static DECLSPEC_NORETURN VOID
+KswordARKAntiBsodInvokeKthreadRoutine(VOID)
+{
+    PVOID kthread;
+    PVOID routineSlot;
+    typedef VOID (NTAPI* KSWORD_ARK_ANTIBSOD_THREAD_ROUTINE)(VOID);
+    KSWORD_ARK_ANTIBSOD_THREAD_ROUTINE routine;
+
+    // Match the sample: call IoGetInitialStack before transferring so any
+    // subsequent unwinder that inspects the initial-stack field sees a
+    // consistent value. Return value is discarded on purpose.
+    (VOID)IoGetInitialStack();
+    kthread = (PVOID)KeGetCurrentThread();
+    routineSlot = (PVOID)((ULONG_PTR)kthread +
+        g_KswordArkAntiBsod.KthreadRoutineOffset);
+    routine = *(KSWORD_ARK_ANTIBSOD_THREAD_ROUTINE*)routineSlot;
+    if (routine != NULL) {
+        routine();
+    }
+    // Fall through into the never-signaled wait so we never return.
+    KswordARKAntiBsodWaitForever();
+}
+
+// The "all processors" hook. Sample: mutate global state, walk every
+// active CPU writing per-CPU state, drop CR8, optionally invoke KTHREAD
+// routine, then wait forever.
+static __int64 __fastcall
+KswordARKAntiBsodSuppressAllProcessorsHook(
+    __int64 arg1,
+    __int64 arg2,
+    __int64 arg3,
+    __int64 arg4
+    )
+{
+    ULONG stackClass;
+    ULONG currentCpu;
+    ULONG cpu;
+    KSWORD_ARK_ANTIBSOD_HOOK_FN original;
+
+    // Track re-entrancy so Uninstall can drain safely.
+    InterlockedIncrement(&g_KswordArkAntiBsod.HookExecutions);
+    InterlockedIncrement(&g_KswordArkAntiBsod.HookInvocationCount);
+    // Classify the caller stack. Zero means "not from the tracked bug
+    // check code range" and we transparently forward to the original.
+    stackClass = KswordARKAntiBsodClassifyBugcheckStackOrigin();
+    if (stackClass == KSWORD_ARK_ANTIBSOD_STACK_NO_TARGET_FRAME) {
+        original = (KSWORD_ARK_ANTIBSOD_HOOK_FN)
+            g_KswordArkAntiBsod.OriginalAllProcessorsRoutine;
+        InterlockedDecrement(&g_KswordArkAntiBsod.HookExecutions);
+        if (original == NULL) {
+            // The reference refuses to forward through a null pointer.
+            // The sample would have crashed; we return zero instead.
+            return 0;
+        }
+        return original(arg1, arg2, arg3, arg4);
+    }
+    // Suppression path. Match the sample writes step by step.
+    // 1. Clear the private state flag DWORD.
+    if (g_KswordArkAntiBsod.BugcheckStateFlagPtr != 0) {
+        *(volatile ULONG*)g_KswordArkAntiBsod.BugcheckStateFlagPtr = 0UL;
+    }
+    // 2. Set the bug-check-in-progress byte to 1.
+    if (g_KswordArkAntiBsod.BugcheckInProgressFlagPtr != 0) {
+        *(volatile UCHAR*)g_KswordArkAntiBsod.BugcheckInProgressFlagPtr = 1;
+    }
+    currentCpu = KeGetCurrentProcessorNumberEx(NULL);
+    // 3. Walk every CPU. Current CPU and remote CPUs get different values.
+    for (cpu = 0; cpu < g_KswordArkAntiBsod.ActiveProcessorCount; ++cpu) {
+        ULONG_PTR prcbState = g_KswordArkAntiBsod.PerCpuPrcbArray[cpu];
+        ULONG_PTR secondary =
+            g_KswordArkAntiBsod.PerCpuSecondaryStateArray[cpu];
+        if (cpu == currentCpu) {
+            if (g_KswordArkAntiBsod.KpcrSecondaryFlagOffset != 0UL &&
+                secondary != 0) {
+                *(volatile UCHAR*)(*(ULONG_PTR*)secondary) = 0;
+            }
+            if (prcbState != 0) {
+                *(volatile ULONG*)
+                    (prcbState + g_KswordArkAntiBsod.KpcrBugcheckStateOffset) = 0UL;
+            }
+        }
+        else {
+            if (g_KswordArkAntiBsod.KpcrSecondaryFlagOffset != 0UL &&
+                secondary != 0) {
+                *(volatile UCHAR*)(*(ULONG_PTR*)secondary) = 1;
+            }
+            if (prcbState != 0) {
+                *(volatile ULONG*)
+                    (prcbState + g_KswordArkAntiBsod.KpcrBugcheckStateOffset) = 5UL;
+            }
+        }
+    }
+    // 4. Legacy build branch: stall then rewrite remote CPU states again.
+    if (g_KswordArkAntiBsod.LegacyBuildMode) {
+        KeStallExecutionProcessor(100000UL);
+        for (cpu = 0; cpu < g_KswordArkAntiBsod.ActiveProcessorCount; ++cpu) {
+            ULONG_PTR prcbState = g_KswordArkAntiBsod.PerCpuPrcbArray[cpu];
+            if (cpu != currentCpu && prcbState != 0) {
+                *(volatile ULONG*)
+                    (prcbState + g_KswordArkAntiBsod.KpcrBugcheckStateOffset) = 34UL;
+            }
+        }
+    }
+    // 5. Drop CR8 so subsequent interrupts are eligible on the local CPU.
+    __writecr8(0);
+    // 6. Terminal boundary transfers to the KTHREAD private routine slot.
+    if (stackClass == KSWORD_ARK_ANTIBSOD_STACK_TERMINAL_BOUNDARY) {
+        InterlockedDecrement(&g_KswordArkAntiBsod.HookExecutions);
+        KswordARKAntiBsodInvokeKthreadRoutine();
+        // Not reached: KswordARKAntiBsodInvokeKthreadRoutine is __noreturn.
+    }
+    // 7. Otherwise wait forever on the never-signaled event.
+    InterlockedDecrement(&g_KswordArkAntiBsod.HookExecutions);
+    KswordARKAntiBsodWaitForever();
+    return 0;
+}
+
+// The "current processor" hook. Same idea but only touches this CPU.
+static __int64 __fastcall
+KswordARKAntiBsodSuppressCurrentProcessorHook(
+    __int64 arg1,
+    __int64 arg2,
+    __int64 arg3,
+    __int64 arg4
+    )
+{
+    ULONG stackClass;
+    ULONG currentCpu;
+    ULONG_PTR prcbState;
+    ULONG_PTR secondary;
+    KSWORD_ARK_ANTIBSOD_HOOK_FN original;
+
+    InterlockedIncrement(&g_KswordArkAntiBsod.HookExecutions);
+    InterlockedIncrement(&g_KswordArkAntiBsod.HookInvocationCount);
+    stackClass = KswordARKAntiBsodClassifyBugcheckStackOrigin();
+    if (stackClass == KSWORD_ARK_ANTIBSOD_STACK_NO_TARGET_FRAME) {
+        original = (KSWORD_ARK_ANTIBSOD_HOOK_FN)
+            g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine;
+        InterlockedDecrement(&g_KswordArkAntiBsod.HookExecutions);
+        if (original == NULL) {
+            return 0;
+        }
+        return original(arg1, arg2, arg3, arg4);
+    }
+    currentCpu = KeGetCurrentProcessorNumberEx(NULL);
+    if (g_KswordArkAntiBsod.BugcheckStateFlagPtr != 0) {
+        *(volatile ULONG*)g_KswordArkAntiBsod.BugcheckStateFlagPtr = 0UL;
+    }
+    if (g_KswordArkAntiBsod.BugcheckInProgressFlagPtr != 0) {
+        *(volatile UCHAR*)g_KswordArkAntiBsod.BugcheckInProgressFlagPtr = 1;
+    }
+    prcbState = g_KswordArkAntiBsod.PerCpuPrcbArray[currentCpu];
+    secondary = g_KswordArkAntiBsod.PerCpuSecondaryStateArray[currentCpu];
+    if (g_KswordArkAntiBsod.KpcrSecondaryFlagOffset != 0UL &&
+        secondary != 0) {
+        *(volatile UCHAR*)(*(ULONG_PTR*)secondary) = 0;
+    }
+    if (prcbState != 0) {
+        *(volatile ULONG*)
+            (prcbState + g_KswordArkAntiBsod.KpcrBugcheckStateOffset) = 0UL;
+    }
+    __writecr8(0);
+    if (stackClass == KSWORD_ARK_ANTIBSOD_STACK_TERMINAL_BOUNDARY) {
+        InterlockedDecrement(&g_KswordArkAntiBsod.HookExecutions);
+        KswordARKAntiBsodInvokeKthreadRoutine();
+    }
+    InterlockedDecrement(&g_KswordArkAntiBsod.HookExecutions);
+    KswordARKAntiBsodWaitForever();
+    return 0;
+}
+
+// ============================================================================
+// Section 10: install / uninstall
+// ============================================================================
+
+// Free per-CPU arrays and reset counts. Safe to call multiple times.
+static VOID
+KswordARKAntiBsodReleasePerCpuArraysLocked(VOID)
+{
+    if (g_KswordArkAntiBsod.PerCpuPrcbArray != NULL) {
+        ExFreePoolWithTag(
+            g_KswordArkAntiBsod.PerCpuPrcbArray,
+            KSWORD_ARK_ANTIBSOD_POOL_TAG);
+        g_KswordArkAntiBsod.PerCpuPrcbArray = NULL;
+    }
+    if (g_KswordArkAntiBsod.PerCpuSecondaryStateArray != NULL) {
+        ExFreePoolWithTag(
+            g_KswordArkAntiBsod.PerCpuSecondaryStateArray,
+            KSWORD_ARK_ANTIBSOD_POOL_TAG);
+        g_KswordArkAntiBsod.PerCpuSecondaryStateArray = NULL;
+    }
+    g_KswordArkAntiBsod.ActiveProcessorCount = 0UL;
+}
+
+// Reset every resolved kernel address in the state struct so a failed
+// or torn-down install cannot leak stale pointers to future queries.
+static VOID
+KswordARKAntiBsodResetResolvedTargetsLocked(VOID)
+{
+    g_KswordArkAntiBsod.NtTextStart = 0;
+    g_KswordArkAntiBsod.NtTextEnd = 0;
+    g_KswordArkAntiBsod.KeBugCheckExAddress = 0;
+    g_KswordArkAntiBsod.BugcheckScanBoundary = 0;
+    g_KswordArkAntiBsod.BugcheckCodeRangeStart = 0;
+    g_KswordArkAntiBsod.BugcheckCodeRangeEnd = 0;
+    g_KswordArkAntiBsod.BugcheckStateFlagPtr = 0;
+    g_KswordArkAntiBsod.KpcrBugcheckStateOffset = 0UL;
+    g_KswordArkAntiBsod.KpcrSecondaryFlagOffset = 0UL;
+    g_KswordArkAntiBsod.BugcheckInProgressFlagPtr = 0;
+    g_KswordArkAntiBsod.AllProcessorsHookSlot = 0;
+    g_KswordArkAntiBsod.CurrentProcessorHookSlot = 0;
+    g_KswordArkAntiBsod.OriginalAllProcessorsRoutine = NULL;
+    g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine = NULL;
+    InterlockedExchange(&g_KswordArkAntiBsod.HookInvocationCount, 0L);
+    InterlockedExchange(&g_KswordArkAntiBsod.SlotExpectedMask, 0L);
+    InterlockedExchange(&g_KswordArkAntiBsod.SlotHitMask, 0L);
+    InterlockedExchange(
+        &g_KswordArkAntiBsod.SupportSummary,
+        (LONG)KSWORD_ARK_ANTIBSOD_SUPPORT_UNKNOWN);
+}
+
+// Compute the two transparency masks from the currently selected profile
+// and the resolved targets. Callers invoke this after the scan pipeline
+// completes so R3 can render per-rule hit/miss.
+static VOID
+KswordARKAntiBsodComputeMasksLocked(VOID)
+{
+    ULONG expected = 0UL;
+    ULONG hit = 0UL;
+    const KSWORD_ARK_ANTIBSOD_PROFILE* profile = g_KswordArkAntiBsod.Profile;
+
+    // Expected mask: which slots have a nonzero pattern length. This is
+    // the operator-supplied part of the state, independent of the target
+    // kernel image.
+    if (profile != NULL) {
+        if (profile->Slot0BugcheckAnchor.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_ANCHOR;
+        }
+        if (profile->Slot1BugcheckCodeStart.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_CODE_START;
+        }
+        if (profile->Slot2BugcheckCodeEnd.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_CODE_END;
+        }
+        if (profile->Slot3StateFlagPtr.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_STATE_FLAG_PTR;
+        }
+        if (profile->Slot4KpcrStateOffset.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_KPCR_STATE_OFFSET;
+        }
+        if (profile->Slot5KpcrSecondaryOffset.Length != 0UL) {
+            expected |=
+                1UL << KSWORD_ARK_ANTIBSOD_SLOT_KPCR_SECONDARY_OFFSET;
+        }
+        if (profile->Slot6InProgressFlagPtr.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_INPROGRESS_FLAG_PTR;
+        }
+        if (profile->Slot7AllProcessorsHookSlot.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_ALL_HOOK_SLOT;
+        }
+        if (profile->Slot8CurrentProcessorHookSlot.Length != 0UL) {
+            expected |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_CURRENT_HOOK_SLOT;
+        }
+    }
+    // Hit mask: which slots resolved to nonzero after the scan. Slot 4/5
+    // are ULONG offsets, everything else is ULONG_PTR.
+    if (g_KswordArkAntiBsod.BugcheckScanBoundary != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_ANCHOR;
+    }
+    if (g_KswordArkAntiBsod.BugcheckCodeRangeStart != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_CODE_START;
+    }
+    if (g_KswordArkAntiBsod.BugcheckCodeRangeEnd != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_CODE_END;
+    }
+    if (g_KswordArkAntiBsod.BugcheckStateFlagPtr != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_STATE_FLAG_PTR;
+    }
+    if (g_KswordArkAntiBsod.KpcrBugcheckStateOffset != 0UL) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_KPCR_STATE_OFFSET;
+    }
+    // KpcrSecondaryFlagOffset is legitimately zero on some builds; when
+    // that is the case, treat the slot as "hit" so a build where the
+    // sample intentionally omits this field is not misclassified.
+    if (g_KswordArkAntiBsod.KpcrSecondaryFlagOffset != 0UL ||
+        (g_KswordArkAntiBsod.Profile != NULL &&
+         g_KswordArkAntiBsod.Profile->Slot5KpcrSecondaryOffset.Length ==
+             0UL)) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_KPCR_SECONDARY_OFFSET;
+    }
+    if (g_KswordArkAntiBsod.BugcheckInProgressFlagPtr != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_INPROGRESS_FLAG_PTR;
+    }
+    if (g_KswordArkAntiBsod.AllProcessorsHookSlot != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_ALL_HOOK_SLOT;
+    }
+    if (g_KswordArkAntiBsod.CurrentProcessorHookSlot != 0) {
+        hit |= 1UL << KSWORD_ARK_ANTIBSOD_SLOT_CURRENT_HOOK_SLOT;
+    }
+    InterlockedExchange(
+        &g_KswordArkAntiBsod.SlotExpectedMask,
+        (LONG)expected);
+    InterlockedExchange(&g_KswordArkAntiBsod.SlotHitMask, (LONG)hit);
+}
+
+// Classify the outcome after a probe or install attempt. Ties expected
+// vs hit mask + profile selection into a single enum for R3.
+static VOID
+KswordARKAntiBsodComputeSupportSummaryLocked(VOID)
+{
+    ULONG expected;
+    ULONG hit;
+    ULONG summary;
+
+    if (g_KswordArkAntiBsod.Profile == NULL) {
+        summary = KSWORD_ARK_ANTIBSOD_SUPPORT_UNSUPPORTED_BUILD;
+    }
+    else {
+        expected = (ULONG)InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.SlotExpectedMask, 0L, 0L);
+        hit = (ULONG)InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.SlotHitMask, 0L, 0L);
+        if (expected == 0UL) {
+            // Zero signatures loaded: this is the shipping default and
+            // the strongest fail-closed guarantee.
+            summary = KSWORD_ARK_ANTIBSOD_SUPPORT_SIGNATURES_EMPTY;
+        }
+        else if ((hit & expected) == expected) {
+            summary = KSWORD_ARK_ANTIBSOD_SUPPORT_FULL_MATCH;
+        }
+        else {
+            summary = KSWORD_ARK_ANTIBSOD_SUPPORT_PARTIAL_MATCH;
+        }
+    }
+    InterlockedExchange(
+        &g_KswordArkAntiBsod.SupportSummary,
+        (LONG)summary);
+}
+
+// The whole install pipeline in one place. Fail-closed at every step.
+static NTSTATUS
+KswordARKAntiBsodInstallLocked(VOID)
+{
+    UNICODE_STRING routineName;
+    const KSWORD_ARK_ANTIBSOD_PROFILE* profile;
+    ULONG_PTR match;
+    NTSTATUS status;
+    ULONG activeCpus;
+
+    // Reject re-install; caller must Uninstall first.
+    if (InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.Installed, 0L, 0L) != 0L) {
+        return STATUS_ALREADY_REGISTERED;
+    }
+    // Clean slate for resolved addresses and per-CPU arrays.
+    KswordARKAntiBsodResetResolvedTargetsLocked();
+    KswordARKAntiBsodReleasePerCpuArraysLocked();
+
+    // Step 1: pick the build profile.
+    if (!KswordARKAntiBsodSelectWindowsBuildProfile()) {
+        return STATUS_NOT_SUPPORTED;
+    }
+    profile = g_KswordArkAntiBsod.Profile;
+    if (profile == NULL) {
+        return STATUS_NOT_SUPPORTED;
+    }
+    // Step 2: locate ntoskrnl .text.
+    if (!KswordARKAntiBsodFindNtoskrnlTextRange()) {
+        return STATUS_NOT_FOUND;
+    }
+    // Step 3: resolve KeBugCheckEx as the primary anchor.
+    RtlInitUnicodeString(&routineName, L"KeBugCheckEx");
+    g_KswordArkAntiBsod.KeBugCheckExAddress =
+        (ULONG_PTR)MmGetSystemRoutineAddress(&routineName);
+    if (g_KswordArkAntiBsod.KeBugCheckExAddress == 0) {
+        return STATUS_NOT_FOUND;
+    }
+    // Step 4: scan the private targets in order, each stage feeding the
+    // next range. This is the multi-level chained scan the sample uses.
+    // Slot 0: anchor.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.KeBugCheckExAddress,
+        profile->Slot0BugcheckAnchor.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot0BugcheckAnchor.Length);
+    g_KswordArkAntiBsod.BugcheckScanBoundary =
+        KswordARKAntiBsodAddOffsetIfNonNull(
+            match,
+            profile->Slot0BugcheckAnchor.AddOffset);
+    // Slot 1: bug-check code range start.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.KeBugCheckExAddress,
+        profile->Slot1BugcheckCodeStart.Pattern,
+        g_KswordArkAntiBsod.BugcheckScanBoundary,
+        profile->Slot1BugcheckCodeStart.Length);
+    g_KswordArkAntiBsod.BugcheckCodeRangeStart =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot1BugcheckCodeStart.DispOffset,
+            profile->Slot1BugcheckCodeStart.TrailingAdjust);
+    // Slot 2: bug-check code range end.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart,
+        profile->Slot2BugcheckCodeEnd.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot2BugcheckCodeEnd.Length);
+    g_KswordArkAntiBsod.BugcheckCodeRangeEnd =
+        KswordARKAntiBsodAddOffsetIfNonNull(
+            match,
+            profile->Slot2BugcheckCodeEnd.AddOffset);
+    // Slot 3: private state flag pointer.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart,
+        profile->Slot3StateFlagPtr.Pattern,
+        g_KswordArkAntiBsod.BugcheckCodeRangeEnd,
+        profile->Slot3StateFlagPtr.Length);
+    g_KswordArkAntiBsod.BugcheckStateFlagPtr =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot3StateFlagPtr.DispOffset,
+            profile->Slot3StateFlagPtr.TrailingAdjust);
+    // Slot 4: PRCB state offset.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot4KpcrStateOffset.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot4KpcrStateOffset.Length);
+    g_KswordArkAntiBsod.KpcrBugcheckStateOffset =
+        KswordARKAntiBsodReadUint32AtOffset(
+            match,
+            profile->Slot4KpcrStateOffset.ReadOffset);
+    // Slot 5: KPCR secondary flag offset.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot5KpcrSecondaryOffset.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot5KpcrSecondaryOffset.Length);
+    g_KswordArkAntiBsod.KpcrSecondaryFlagOffset =
+        KswordARKAntiBsodReadUint32AtOffset(
+            match,
+            profile->Slot5KpcrSecondaryOffset.ReadOffset);
+    // Slot 6: bug-check-in-progress byte.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot6InProgressFlagPtr.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot6InProgressFlagPtr.Length);
+    g_KswordArkAntiBsod.BugcheckInProgressFlagPtr =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot6InProgressFlagPtr.DispOffset,
+            profile->Slot6InProgressFlagPtr.TrailingAdjust);
+    // Slot 7: all-processors hook slot.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart,
+        profile->Slot7AllProcessorsHookSlot.Pattern,
+        g_KswordArkAntiBsod.BugcheckCodeRangeEnd,
+        profile->Slot7AllProcessorsHookSlot.Length);
+    g_KswordArkAntiBsod.AllProcessorsHookSlot =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot7AllProcessorsHookSlot.DispOffset,
+            profile->Slot7AllProcessorsHookSlot.TrailingAdjust);
+    // Slot 8: current-processor hook slot.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot8CurrentProcessorHookSlot.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot8CurrentProcessorHookSlot.Length);
+    g_KswordArkAntiBsod.CurrentProcessorHookSlot =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot8CurrentProcessorHookSlot.DispOffset,
+            profile->Slot8CurrentProcessorHookSlot.TrailingAdjust);
+    // Publish the transparency masks and the support summary now that
+    // every scan has run. R3 can observe them via QUERY even when Install
+    // will fail-close below.
+    KswordARKAntiBsodComputeMasksLocked();
+    KswordARKAntiBsodComputeSupportSummaryLocked();
+    // Step 5: fail-closed validation. This block is the safety hardening
+    // the analysis report identifies as missing from the sample.
+    if (g_KswordArkAntiBsod.BugcheckScanBoundary == 0 ||
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart == 0 ||
+        g_KswordArkAntiBsod.BugcheckCodeRangeEnd == 0 ||
+        g_KswordArkAntiBsod.BugcheckStateFlagPtr == 0 ||
+        g_KswordArkAntiBsod.KpcrBugcheckStateOffset == 0UL ||
+        g_KswordArkAntiBsod.BugcheckInProgressFlagPtr == 0 ||
+        g_KswordArkAntiBsod.AllProcessorsHookSlot == 0 ||
+        g_KswordArkAntiBsod.CurrentProcessorHookSlot == 0) {
+        // Any zero here means an empty signature or an unmatched scan.
+        // Refuse to write hook slots. This is the default state when
+        // shipping without operator-supplied signature bytes.
+        return STATUS_OBJECT_NAME_NOT_FOUND;
+    }
+    // Step 6: allocate per-CPU arrays and capture state through IPI.
+    activeCpus = KeQueryActiveProcessorCountEx(ALL_PROCESSOR_GROUPS);
+    if (activeCpus == 0UL || activeCpus > 2048UL) {
+        // Refuse absurd counts before they overflow the allocations.
+        return STATUS_INVALID_DEVICE_STATE;
+    }
+    g_KswordArkAntiBsod.ActiveProcessorCount = activeCpus;
+    g_KswordArkAntiBsod.PerCpuPrcbArray = (ULONG_PTR*)
+        KswordARKAntiBsodAllocateNonPaged(
+            (SIZE_T)activeCpus * sizeof(ULONG_PTR));
+    g_KswordArkAntiBsod.PerCpuSecondaryStateArray = (ULONG_PTR*)
+        KswordARKAntiBsodAllocateNonPaged(
+            (SIZE_T)activeCpus * sizeof(ULONG_PTR));
+    // KswordARKAntiBsodAllocateNonPaged does not zero on the fallback path,
+    // so wipe both arrays before the IPI can partially populate them.
+    if (g_KswordArkAntiBsod.PerCpuPrcbArray != NULL) {
+        RtlZeroMemory(
+            g_KswordArkAntiBsod.PerCpuPrcbArray,
+            (SIZE_T)activeCpus * sizeof(ULONG_PTR));
+    }
+    if (g_KswordArkAntiBsod.PerCpuSecondaryStateArray != NULL) {
+        RtlZeroMemory(
+            g_KswordArkAntiBsod.PerCpuSecondaryStateArray,
+            (SIZE_T)activeCpus * sizeof(ULONG_PTR));
+    }
+    if (g_KswordArkAntiBsod.PerCpuPrcbArray == NULL ||
+        g_KswordArkAntiBsod.PerCpuSecondaryStateArray == NULL) {
+        KswordARKAntiBsodReleasePerCpuArraysLocked();
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+    (VOID)KeIpiGenericCall(
+        (PKIPI_BROADCAST_WORKER)KswordARKAntiBsodCapturePerCpuBugcheckState,
+        0);
+    // Step 7: initialize the never-signaled event.
+    KeInitializeEvent(
+        &g_KswordArkAntiBsod.NeverSignaledEvent,
+        KSWORD_ARK_ANTIBSOD_EVENT_KIND,
+        FALSE);
+    // Step 8: save the original targets, then overwrite the hook slots.
+    // The sample uses an atomic pair of pointer stores; on x64 a naturally
+    // aligned pointer write is atomic already.
+    g_KswordArkAntiBsod.OriginalAllProcessorsRoutine =
+        *(PVOID*)g_KswordArkAntiBsod.AllProcessorsHookSlot;
+    g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine =
+        *(PVOID*)g_KswordArkAntiBsod.CurrentProcessorHookSlot;
+    __try {
+        // Wrap the two writes in SEH so a slot located in a read-only or
+        // stale mapping does not immediately fault the driver. This is
+        // not in the sample; the reference adds it as defense in depth.
+        *(PVOID*)g_KswordArkAntiBsod.AllProcessorsHookSlot =
+            (PVOID)(ULONG_PTR)KswordARKAntiBsodSuppressAllProcessorsHook;
+        *(PVOID*)g_KswordArkAntiBsod.CurrentProcessorHookSlot =
+            (PVOID)(ULONG_PTR)KswordARKAntiBsodSuppressCurrentProcessorHook;
+        status = STATUS_SUCCESS;
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER) {
+        status = GetExceptionCode();
+    }
+    if (!NT_SUCCESS(status)) {
+        // Roll back: the slot writes may have partially succeeded above.
+        __try {
+            if (g_KswordArkAntiBsod.OriginalAllProcessorsRoutine != NULL) {
+                *(PVOID*)g_KswordArkAntiBsod.AllProcessorsHookSlot =
+                    g_KswordArkAntiBsod.OriginalAllProcessorsRoutine;
+            }
+            if (g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine != NULL) {
+                *(PVOID*)g_KswordArkAntiBsod.CurrentProcessorHookSlot =
+                    g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine;
+            }
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER) {
+            // Best effort. Nothing else useful we can do here.
+        }
+        KswordARKAntiBsodReleasePerCpuArraysLocked();
+        return status;
+    }
+    // All state is live now. Publish flags last.
+    InterlockedExchange(&g_KswordArkAntiBsod.HooksActive, 1L);
+    InterlockedExchange(&g_KswordArkAntiBsod.Installed, 1L);
+    // Re-publish the summary now that hooks are actually live; this only
+    // changes the reported hookInvocationCount when a real firing occurs
+    // later, but the summary value stays FULL_MATCH for the R3 QUERY view.
+    KswordARKAntiBsodComputeSupportSummaryLocked();
+    return STATUS_SUCCESS;
+}
+
+// Run the entire scan pipeline read-only. No hook writes, no per-CPU
+// allocation, no IPI. The response afterwards carries per-slot expected
+// and hit masks plus the support summary so R3 can render "current rules
+// hit / current system supported" without any side effect.
+static NTSTATUS
+KswordARKAntiBsodProbeLocked(VOID)
+{
+    UNICODE_STRING routineName;
+    const KSWORD_ARK_ANTIBSOD_PROFILE* profile;
+    ULONG_PTR match;
+
+    // Probe requires no confirmation because it neither installs nor
+    // dereferences any private slot. Do refuse while an install is live
+    // so the observable state is not overwritten under a live hook.
+    if (InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.Installed, 0L, 0L) != 0L) {
+        return STATUS_ALREADY_REGISTERED;
+    }
+    // Start from a clean slate so a previous probe cannot pollute masks.
+    KswordARKAntiBsodResetResolvedTargetsLocked();
+
+    // Step 1: pick a profile.
+    if (!KswordARKAntiBsodSelectWindowsBuildProfile()) {
+        // No profile: report support summary immediately and leave the
+        // rest of the state zero.
+        KswordARKAntiBsodComputeMasksLocked();
+        KswordARKAntiBsodComputeSupportSummaryLocked();
+        return STATUS_NOT_SUPPORTED;
+    }
+    profile = g_KswordArkAntiBsod.Profile;
+    // Step 2: resolve ntoskrnl.
+    if (!KswordARKAntiBsodFindNtoskrnlTextRange()) {
+        KswordARKAntiBsodComputeMasksLocked();
+        KswordARKAntiBsodComputeSupportSummaryLocked();
+        return STATUS_NOT_FOUND;
+    }
+    RtlInitUnicodeString(&routineName, L"KeBugCheckEx");
+    g_KswordArkAntiBsod.KeBugCheckExAddress =
+        (ULONG_PTR)MmGetSystemRoutineAddress(&routineName);
+    if (g_KswordArkAntiBsod.KeBugCheckExAddress == 0) {
+        KswordARKAntiBsodComputeMasksLocked();
+        KswordARKAntiBsodComputeSupportSummaryLocked();
+        return STATUS_NOT_FOUND;
+    }
+    // Step 3: run all 9 scans in the exact same order Install uses. The
+    // wildcard scanner returns 0 when either the pattern or the length
+    // is zero, so every empty slot cleanly ends up as a miss.
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.KeBugCheckExAddress,
+        profile->Slot0BugcheckAnchor.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot0BugcheckAnchor.Length);
+    g_KswordArkAntiBsod.BugcheckScanBoundary =
+        KswordARKAntiBsodAddOffsetIfNonNull(
+            match, profile->Slot0BugcheckAnchor.AddOffset);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.KeBugCheckExAddress,
+        profile->Slot1BugcheckCodeStart.Pattern,
+        g_KswordArkAntiBsod.BugcheckScanBoundary,
+        profile->Slot1BugcheckCodeStart.Length);
+    g_KswordArkAntiBsod.BugcheckCodeRangeStart =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot1BugcheckCodeStart.DispOffset,
+            profile->Slot1BugcheckCodeStart.TrailingAdjust);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart,
+        profile->Slot2BugcheckCodeEnd.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot2BugcheckCodeEnd.Length);
+    g_KswordArkAntiBsod.BugcheckCodeRangeEnd =
+        KswordARKAntiBsodAddOffsetIfNonNull(
+            match, profile->Slot2BugcheckCodeEnd.AddOffset);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart,
+        profile->Slot3StateFlagPtr.Pattern,
+        g_KswordArkAntiBsod.BugcheckCodeRangeEnd,
+        profile->Slot3StateFlagPtr.Length);
+    g_KswordArkAntiBsod.BugcheckStateFlagPtr =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot3StateFlagPtr.DispOffset,
+            profile->Slot3StateFlagPtr.TrailingAdjust);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot4KpcrStateOffset.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot4KpcrStateOffset.Length);
+    g_KswordArkAntiBsod.KpcrBugcheckStateOffset =
+        KswordARKAntiBsodReadUint32AtOffset(
+            match, profile->Slot4KpcrStateOffset.ReadOffset);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot5KpcrSecondaryOffset.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot5KpcrSecondaryOffset.Length);
+    g_KswordArkAntiBsod.KpcrSecondaryFlagOffset =
+        KswordARKAntiBsodReadUint32AtOffset(
+            match, profile->Slot5KpcrSecondaryOffset.ReadOffset);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot6InProgressFlagPtr.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot6InProgressFlagPtr.Length);
+    g_KswordArkAntiBsod.BugcheckInProgressFlagPtr =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot6InProgressFlagPtr.DispOffset,
+            profile->Slot6InProgressFlagPtr.TrailingAdjust);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.BugcheckCodeRangeStart,
+        profile->Slot7AllProcessorsHookSlot.Pattern,
+        g_KswordArkAntiBsod.BugcheckCodeRangeEnd,
+        profile->Slot7AllProcessorsHookSlot.Length);
+    g_KswordArkAntiBsod.AllProcessorsHookSlot =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot7AllProcessorsHookSlot.DispOffset,
+            profile->Slot7AllProcessorsHookSlot.TrailingAdjust);
+    match = KswordARKAntiBsodFindWildcardBytePattern(
+        g_KswordArkAntiBsod.NtTextStart,
+        profile->Slot8CurrentProcessorHookSlot.Pattern,
+        g_KswordArkAntiBsod.NtTextEnd,
+        profile->Slot8CurrentProcessorHookSlot.Length);
+    g_KswordArkAntiBsod.CurrentProcessorHookSlot =
+        KswordARKAntiBsodResolveRipRelativeTarget(
+            match,
+            profile->Slot8CurrentProcessorHookSlot.DispOffset,
+            profile->Slot8CurrentProcessorHookSlot.TrailingAdjust);
+    // Publish the transparency masks and summary; Probe never writes a
+    // private slot regardless of outcome.
+    KswordARKAntiBsodComputeMasksLocked();
+    KswordARKAntiBsodComputeSupportSummaryLocked();
+    return STATUS_SUCCESS;
+}
+
+// Restore the two hook slots and free per-CPU arrays. Fails when a hook
+// is still executing on another CPU: on modern Windows the hook path never
+// returns, so this branch mostly serves as a diagnostic in a research VM.
+static NTSTATUS
+KswordARKAntiBsodUninstallLocked(VOID)
+{
+    // Refuse if never installed.
+    if (InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.Installed, 0L, 0L) == 0L) {
+        return STATUS_SUCCESS;
+    }
+    // Refuse if a hook is still in flight.
+    if (InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.HookExecutions, 0L, 0L) != 0L) {
+        return STATUS_DEVICE_BUSY;
+    }
+    InterlockedExchange(&g_KswordArkAntiBsod.HooksActive, 0L);
+    __try {
+        if (g_KswordArkAntiBsod.AllProcessorsHookSlot != 0 &&
+            g_KswordArkAntiBsod.OriginalAllProcessorsRoutine != NULL) {
+            *(PVOID*)g_KswordArkAntiBsod.AllProcessorsHookSlot =
+                g_KswordArkAntiBsod.OriginalAllProcessorsRoutine;
+        }
+        if (g_KswordArkAntiBsod.CurrentProcessorHookSlot != 0 &&
+            g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine != NULL) {
+            *(PVOID*)g_KswordArkAntiBsod.CurrentProcessorHookSlot =
+                g_KswordArkAntiBsod.OriginalCurrentProcessorRoutine;
+        }
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER) {
+        // Ignore: if the slot itself is inaccessible we still want to
+        // fall through and release our own allocations.
+    }
+    KswordARKAntiBsodReleasePerCpuArraysLocked();
+    KswordARKAntiBsodResetResolvedTargetsLocked();
+    InterlockedExchange(&g_KswordArkAntiBsod.Installed, 0L);
+    return STATUS_SUCCESS;
+}
+
+// ============================================================================
+// Section 11: response bookkeeping + IOCTL
+// ============================================================================
+
+static ULONG
+KswordARKAntiBsodStateFlagsLocked(VOID)
+{
+    ULONG flags = 0UL;
+
+    if (InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.Installed, 0L, 0L) != 0L) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_INSTALLED;
+    }
+    if (InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.HooksActive, 0L, 0L) != 0L) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_HOOKS_ACTIVE;
+    }
+    if (g_KswordArkAntiBsod.LegacyBuildMode) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_LEGACY_BUILD;
+    }
+    if (g_KswordArkAntiBsod.Profile != NULL) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_PROFILE_SELECTED;
+    }
+    if (g_KswordArkAntiBsod.NtTextStart != 0 &&
+        g_KswordArkAntiBsod.NtTextEnd != 0) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_MODULE_RANGE_RESOLVED;
+    }
+    if (g_KswordArkAntiBsod.AllProcessorsHookSlot != 0 &&
+        g_KswordArkAntiBsod.CurrentProcessorHookSlot != 0) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_TARGETS_RESOLVED;
+    }
+    if (g_KswordArkAntiBsod.PerCpuPrcbArray != NULL &&
+        g_KswordArkAntiBsod.PerCpuSecondaryStateArray != NULL) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_PER_CPU_STATE_CAPTURED;
+    }
+    // If Slot0's length is zero across all profiles the caller can see the
+    // signature table is empty. Cheap to compute and useful for R3.
+    if (g_KswordArkAntiBsod.Profile == NULL ||
+        g_KswordArkAntiBsod.Profile->Slot0BugcheckAnchor.Length == 0UL) {
+        flags |= KSWORD_ARK_ANTIBSOD_STATE_SIGNATURES_EMPTY;
+    }
+    return flags;
+}
+
+static VOID
+KswordARKAntiBsodFillResponseLocked(
+    _Out_ KSWORD_ARK_ANTIBSOD_RESPONSE* Response,
+    _In_ ULONG ProtocolStatus
+    )
+{
+    RtlZeroMemory(Response, sizeof(*Response));
+    Response->size = sizeof(*Response);
+    Response->version = KSWORD_ARK_ANTIBSOD_PROTOCOL_VERSION;
+    Response->status = ProtocolStatus;
+    Response->stateFlags = KswordARKAntiBsodStateFlagsLocked();
+    Response->windowsBuildNumber = g_KswordArkAntiBsod.WindowsBuildNumber;
+    Response->selectedProfileIndex = g_KswordArkAntiBsod.SelectedProfileIndex;
+    Response->kthreadRoutineOffset = g_KswordArkAntiBsod.KthreadRoutineOffset;
+    Response->activeProcessorCount = g_KswordArkAntiBsod.ActiveProcessorCount;
+    Response->hookInvocationCount = (ULONG)InterlockedCompareExchange(
+        &g_KswordArkAntiBsod.HookInvocationCount, 0L, 0L);
+    Response->lastStatus = (LONG)g_KswordArkAntiBsod.LastStatus;
+    Response->slotExpectedMask = (ULONG)InterlockedCompareExchange(
+        &g_KswordArkAntiBsod.SlotExpectedMask, 0L, 0L);
+    Response->slotHitMask = (ULONG)InterlockedCompareExchange(
+        &g_KswordArkAntiBsod.SlotHitMask, 0L, 0L);
+    Response->supportSummary = (ULONG)InterlockedCompareExchange(
+        &g_KswordArkAntiBsod.SupportSummary, 0L, 0L);
+}
+
+VOID
+KswordARKAntiBsodInitialize(
+    VOID
+    )
+{
+    // Zero the entire runtime; synchronization primitives live here too.
+    RtlZeroMemory(&g_KswordArkAntiBsod, sizeof(g_KswordArkAntiBsod));
+    ExInitializeFastMutex(&g_KswordArkAntiBsod.ControlLock);
+    g_KswordArkAntiBsod.LastStatus = STATUS_SUCCESS;
+    // Also zero the signature table so a reload cannot inherit stale
+    // patterns from another instance loaded earlier in this boot.
+    RtlZeroMemory(
+        g_KswordArkAntiBsodProfiles,
+        sizeof(g_KswordArkAntiBsodProfiles));
+}
+
+VOID
+KswordARKAntiBsodUninitialize(
+    VOID
+    )
+{
+    NTSTATUS status;
+
+    ExAcquireFastMutex(&g_KswordArkAntiBsod.ControlLock);
+    status = KswordARKAntiBsodUninstallLocked();
+    g_KswordArkAntiBsod.LastStatus = status;
+    ExReleaseFastMutex(&g_KswordArkAntiBsod.ControlLock);
+}
+
+NTSTATUS
+KswordARKAntiBsodIoctlConfigure(
+    _In_ WDFDEVICE Device,
+    _In_ WDFREQUEST Request,
+    _In_ size_t InputBufferLength,
+    _In_ size_t OutputBufferLength,
+    _Out_ size_t* BytesReturned
+    )
+{
+    KSWORD_ARK_ANTIBSOD_REQUEST* input = NULL;
+    KSWORD_ARK_ANTIBSOD_RESPONSE* output = NULL;
+    NTSTATUS status;
+    ULONG protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_INVALID_REQUEST;
+    NTSTATUS installStatus;
+
+    UNREFERENCED_PARAMETER(Device);
+
+    if (BytesReturned == NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    *BytesReturned = 0U;
+    status = WdfRequestRetrieveInputBuffer(
+        Request, sizeof(*input), (PVOID*)&input, NULL);
+    if (!NT_SUCCESS(status) || InputBufferLength < sizeof(*input)) {
+        return NT_SUCCESS(status) ? STATUS_BUFFER_TOO_SMALL : status;
+    }
+    status = WdfRequestRetrieveOutputBuffer(
+        Request, sizeof(*output), (PVOID*)&output, NULL);
+    if (!NT_SUCCESS(status) || OutputBufferLength < sizeof(*output)) {
+        return NT_SUCCESS(status) ? STATUS_BUFFER_TOO_SMALL : status;
+    }
+
+    ExAcquireFastMutex(&g_KswordArkAntiBsod.ControlLock);
+    // Strict fixed-length validation of every reserved field.
+    if (input->size != sizeof(*input) ||
+        input->version != KSWORD_ARK_ANTIBSOD_PROTOCOL_VERSION ||
+        (input->flags & ~KSWORD_ARK_ANTIBSOD_FLAG_UI_CONFIRMED) != 0UL ||
+        input->reserved0 != 0UL ||
+        input->reserved1 != 0UL ||
+        input->reserved2 != 0UL) {
+        g_KswordArkAntiBsod.LastStatus = STATUS_INVALID_PARAMETER;
+        protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_INVALID_REQUEST;
+    }
+    else if (input->action == KSWORD_ARK_ANTIBSOD_ACTION_QUERY) {
+        protocolStatus = InterlockedCompareExchange(
+            &g_KswordArkAntiBsod.Installed, 0L, 0L) != 0L
+            ? KSWORD_ARK_ANTIBSOD_STATUS_ACTIVE
+            : KSWORD_ARK_ANTIBSOD_STATUS_INACTIVE;
+    }
+    else if (input->action == KSWORD_ARK_ANTIBSOD_ACTION_PROBE) {
+        // PROBE runs the read-only scan pipeline and updates the masks
+        // and support summary; it never writes any private slot.
+        installStatus = KswordARKAntiBsodProbeLocked();
+        g_KswordArkAntiBsod.LastStatus = installStatus;
+        if (installStatus == STATUS_NOT_SUPPORTED) {
+            protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_PROFILE_MISSING;
+        }
+        else if (installStatus == STATUS_NOT_FOUND) {
+            protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_MODULE_NOT_FOUND;
+        }
+        else if (installStatus == STATUS_ALREADY_REGISTERED) {
+            protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_ACTIVE;
+        }
+        else {
+            // Probe succeeded structurally. The support summary decides
+            // whether the current image is a full match, partial match,
+            // or the shipping SIGNATURES_EMPTY default.
+            protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_INACTIVE;
+        }
+    }
+    else if (input->action == KSWORD_ARK_ANTIBSOD_ACTION_UNINSTALL) {
+        installStatus = KswordARKAntiBsodUninstallLocked();
+        g_KswordArkAntiBsod.LastStatus = installStatus;
+        protocolStatus = NT_SUCCESS(installStatus)
+            ? KSWORD_ARK_ANTIBSOD_STATUS_INACTIVE
+            : KSWORD_ARK_ANTIBSOD_STATUS_BUSY;
+    }
+    else if (input->action == KSWORD_ARK_ANTIBSOD_ACTION_INSTALL) {
+        if ((input->flags & KSWORD_ARK_ANTIBSOD_FLAG_UI_CONFIRMED) == 0UL ||
+            input->confirmationToken !=
+                KSWORD_ARK_ANTIBSOD_CONFIRMATION_TOKEN) {
+            // Enable requires the explicit UI-side confirmation contract.
+            g_KswordArkAntiBsod.LastStatus = STATUS_ACCESS_DENIED;
+            protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_CONFIRMATION_NEEDED;
+        }
+        else {
+            installStatus = KswordARKAntiBsodInstallLocked();
+            g_KswordArkAntiBsod.LastStatus = installStatus;
+            if (installStatus == STATUS_SUCCESS) {
+                protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_ACTIVE;
+            }
+            else if (installStatus == STATUS_ALREADY_REGISTERED) {
+                protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_ACTIVE;
+            }
+            else if (installStatus == STATUS_NOT_SUPPORTED) {
+                protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_PROFILE_MISSING;
+            }
+            else if (installStatus == STATUS_NOT_FOUND) {
+                protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_MODULE_NOT_FOUND;
+            }
+            else if (installStatus == STATUS_OBJECT_NAME_NOT_FOUND) {
+                protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_SIGNATURE_NOT_FOUND;
+            }
+            else {
+                protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_HOOK_INSTALL_FAILED;
+            }
+        }
+    }
+    else {
+        g_KswordArkAntiBsod.LastStatus = STATUS_INVALID_PARAMETER;
+        protocolStatus = KSWORD_ARK_ANTIBSOD_STATUS_INVALID_REQUEST;
+    }
+    KswordARKAntiBsodFillResponseLocked(output, protocolStatus);
+    ExReleaseFastMutex(&g_KswordArkAntiBsod.ControlLock);
+    *BytesReturned = sizeof(*output);
+    return STATUS_SUCCESS;
+}
+
+#endif // KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED

--- a/KswordARKDriver/src/features/bugcheck/bugcheck_shield.c
+++ b/KswordARKDriver/src/features/bugcheck/bugcheck_shield.c
@@ -1,0 +1,872 @@
+#include "ark/ark_driver.h"
+
+/*++
+
+Module Name:
+
+    bugcheck_shield.c
+
+Abstract:
+
+    PatchGuard-safe bugcheck buffer backend.
+
+    Motivation and design boundaries
+    --------------------------------
+    Publicly circulated reverse-engineering of private-slot
+    "Disable-PatchGuard" style samples shows the same recipe: enumerate
+    ntoskrnl by signature, overwrite undocumented function-pointer slots
+    and permanently wait on an unsignaled event so the intercepted
+    bug-check path never completes. That approach fails Windows kernel
+    integrity checks (HVCI, PatchGuard, WHQL) and leaves the kernel in a
+    non-recoverable state. It is presented as an example of what not to
+    ship in a signed driver.
+
+    The Shield keeps the "extend the window before the machine leaves the
+    bug-check screen" observation from those samples but implements it
+    only through documented callbacks:
+
+      * KeRegisterBugCheckCallback for the earliest phase.
+      * KeRegisterBugCheckReasonCallback for KbCallbackSecondaryDumpData,
+        KbCallbackDumpIo and KbCallbackAddPages.
+
+    Every callback performs a bounded KeStallExecutionProcessor loop that
+    respects a global remaining-budget accumulator. The Shield never
+    writes to ntoskrnl code, private KPCR/KPRCB/KTHREAD offsets, CR0, CR4,
+    CR8, MSRs, SSDT, IDT or GDT. It never waits on an unsignaled event.
+    It always yields back to Windows so the normal dump path can run.
+
+    DriverEntry only initializes synchronization state. Callbacks are
+    installed only after an IOCTL with the KSHL confirmation token and
+    UI-confirmed flag arrives. Driver unload drains any in-flight
+    callback invocations before deregistering the records.
+
+Environment:
+
+    Kernel-mode Driver Framework
+
+--*/
+
+// x64 only: the driver as a whole is x64-only; the Shield reuses the same
+// gate so a mistaken 32-bit build does not silently link against the wrong
+// ULONG_PTR/pointer semantics used inside the timeline ring.
+#if !defined(_WIN64)
+#error The bugcheck Shield only supports x64 builds.
+#endif
+
+// KSHL is derived from the shared header. Redefining it locally would allow
+// R0 and R3 to drift; instead we assert the token matches at compile time so
+// any accidental change trips the build before anyone reaches a real machine.
+C_ASSERT(KSWORD_ARK_BUGCHECK_SHIELD_CONFIRMATION_TOKEN == 0x4C48534BUL);
+
+// Fixed component name shown by the kernel when logging callback failures.
+static UCHAR g_KswordArkBugcheckShieldComponent[] = "KswordBugcheckShield";
+
+// State is fully static and lives in nonpaged BSS. The Shield never allocates
+// at callback time; every field it touches on the crash path is a member of
+// this structure.
+typedef struct _KSWORD_ARK_BUGCHECK_SHIELD_STATE
+{
+    // ControlLock serializes IOCTL enable/disable transitions at
+    // PASSIVE_LEVEL. It is never acquired by callback code, which can run at
+    // HIGH_LEVEL on the crashing processor.
+    FAST_MUTEX ControlLock;
+    // Enabled is set to 1 after all requested reason callbacks registered
+    // successfully. Callbacks bail out cheaply when Enabled is 0.
+    volatile LONG Enabled;
+    // Fired is set to 1 on the first callback observed after enable so R3
+    // can distinguish "installed but never fired" from "actually invoked".
+    volatile LONG Fired;
+    // FireCount tracks how many callback executions have completed. It is
+    // decremented after each callback returns so unload can drain safely.
+    volatile LONG FireCount;
+    // Executions counts nesting per callback entry; used to prevent unload
+    // from deregistering while another CPU is inside a Shield callback.
+    volatile LONG Executions;
+    // TimelineNextIndex is monotonically incremented; entries beyond the
+    // ring size are dropped to keep the response bounded.
+    volatile LONG TimelineNextIndex;
+    // TimelineCommittedCount is the visible size for R3 snapshots.
+    volatile LONG TimelineCommittedCount;
+    // RemainingBudgetMs is a global buffer budget shared across callbacks
+    // so multiple stages cannot exceed TotalSeconds. It is set on enable
+    // and drained by callbacks; it never goes negative.
+    volatile LONG RemainingBudgetMs;
+    // Configured knobs mirror the last successful enable request; used for
+    // both response serialization and callback stall duration.
+    ULONG ReasonMask;
+    ULONG StageSeconds;
+    ULONG TotalSeconds;
+    // Registration bookkeeping for KeDeregister* on disable/unload.
+    KBUGCHECK_CALLBACK_RECORD ClassicRecord;
+    KBUGCHECK_REASON_CALLBACK_RECORD SecondaryRecord;
+    KBUGCHECK_REASON_CALLBACK_RECORD DumpIoRecord;
+    KBUGCHECK_REASON_CALLBACK_RECORD AddPagesRecord;
+    // The kernel keeps a pointer to the callback buffer; we hand it a
+    // ULONG per callback record. The value itself is not used by Windows,
+    // it only needs to remain valid until the record is deregistered.
+    ULONG ClassicBuffer;
+    ULONG ReasonBuffer;
+    BOOLEAN ClassicRegistered;
+    BOOLEAN SecondaryRegistered;
+    BOOLEAN DumpIoRegistered;
+    BOOLEAN AddPagesRegistered;
+    // Last kernel status reported to R3 for diagnostics.
+    NTSTATUS LastStatus;
+    // Timeline ring is fixed size; entries are visible only after they are
+    // fully written and TimelineCommittedCount is bumped.
+    KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRY
+        Timeline[KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRIES];
+} KSWORD_ARK_BUGCHECK_SHIELD_STATE;
+
+// Single global state; the Shield is not per-device.
+static KSWORD_ARK_BUGCHECK_SHIELD_STATE g_KswordArkBugcheckShield;
+
+// Forward declarations for the four callback entry points.
+static VOID
+KswordARKBugcheckShieldClassicCallback(
+    _In_ PVOID Buffer,
+    _In_ ULONG Length
+    );
+
+static VOID
+KswordARKBugcheckShieldReasonCallback(
+    _In_ KBUGCHECK_CALLBACK_REASON Reason,
+    _In_ struct _KBUGCHECK_REASON_CALLBACK_RECORD* Record,
+    _In_ PVOID ReasonSpecificData,
+    _In_ ULONG ReasonSpecificDataLength
+    );
+
+// KeQueryInterruptTime returns 100ns units. This helper converts a
+// millisecond count to interrupt-time units so we can compare against a
+// KeQueryInterruptTime baseline without integer overflow risk on the
+// bug-check path.
+static ULONGLONG
+KswordARKBugcheckShieldMsToInterruptUnits(
+    _In_ ULONG Milliseconds
+    )
+{
+    // 10 000 100ns ticks per millisecond; guard against overflow by taking
+    // ULONGLONG on both operands even though ULONG * 10000 fits in 64-bit.
+    return (ULONGLONG)Milliseconds * 10000ULL;
+}
+
+// Compute how long this callback is allowed to stall. The per-stage cap is
+// bounded by the global remaining budget; when the global budget is empty
+// the callback returns immediately so downstream Windows work is not
+// starved.
+static ULONG
+KswordARKBugcheckShieldClaimStallBudgetMs(
+    _In_ ULONG StageSeconds
+    )
+{
+    LONG desired;
+    LONG remaining;
+    LONG claim;
+    LONG updated;
+
+    // Convert stage seconds to milliseconds; the shared header caps the
+    // value at KSWORD_ARK_BUGCHECK_SHIELD_STAGE_MAX_SECONDS so this cannot
+    // wrap.
+    desired = (LONG)(StageSeconds * 1000UL);
+    for (;;) {
+        // Read the current remaining budget. Loop until CAS succeeds so we
+        // are correct even if multiple callbacks race on different CPUs.
+        remaining = InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.RemainingBudgetMs,
+            0L,
+            0L);
+        if (remaining <= 0L) {
+            // Global budget is exhausted; no further stall permitted.
+            return 0UL;
+        }
+        claim = remaining < desired ? remaining : desired;
+        // Publish the new remaining value only if nobody else changed it.
+        updated = InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.RemainingBudgetMs,
+            remaining - claim,
+            remaining);
+        if (updated == remaining) {
+            return (ULONG)claim;
+        }
+    }
+}
+
+// Stall the current processor for approximately the requested duration.
+// The loop uses 50µs KeStallExecutionProcessor steps and re-checks elapsed
+// time on every iteration so the stall never significantly overshoots.
+static VOID
+KswordARKBugcheckShieldStallMs(
+    _In_ ULONG Milliseconds
+    )
+{
+    ULONGLONG deadline;
+    ULONGLONG now;
+
+    if (Milliseconds == 0UL) {
+        // Empty stall — fall through so the timeline still records the hit.
+        return;
+    }
+    // KeQueryInterruptTime is callable at any IRQL and monotonic across
+    // processors, which is the property we need on the crash path.
+    now = KeQueryInterruptTime();
+    deadline = now + KswordARKBugcheckShieldMsToInterruptUnits(Milliseconds);
+    while (now < deadline) {
+        // 50µs per step keeps the loop responsive without spinning too
+        // tightly on the memory subsystem.
+        KeStallExecutionProcessor(50UL);
+        now = KeQueryInterruptTime();
+    }
+}
+
+// Publish a timeline entry describing the callback that just ran. Called
+// after the stall completes so the recorded duration is accurate.
+static VOID
+KswordARKBugcheckShieldRecordTimeline(
+    _In_ ULONG Reason,
+    _In_ ULONG StalledMilliseconds
+    )
+{
+    LONG index;
+    ULONG cpu;
+
+    // Reserve the next ring slot; drop the entry when the ring is full so
+    // the crash response never grows beyond its fixed layout.
+    index = InterlockedIncrement(
+        &g_KswordArkBugcheckShield.TimelineNextIndex) - 1L;
+    if (index < 0L ||
+        (ULONG)index >= KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRIES) {
+        return;
+    }
+    // KeGetCurrentProcessorNumberEx is documented for any IRQL and returns
+    // the processor that is actually running the callback.
+    cpu = KeGetCurrentProcessorNumberEx(NULL);
+    g_KswordArkBugcheckShield.Timeline[index].reason = Reason;
+    // Bug-check code is not exposed to reason callbacks; leave it 0 so
+    // R3 renders it as "unknown".  We keep the field for wire-format
+    // compatibility if a future kernel exposes the value.
+    g_KswordArkBugcheckShield.Timeline[index].bugcheckCode = 0UL;
+    g_KswordArkBugcheckShield.Timeline[index].cpu = cpu;
+    g_KswordArkBugcheckShield.Timeline[index].stalledMilliseconds =
+        StalledMilliseconds;
+    // Publish the entry only after all fields are written so a reader
+    // observing TimelineCommittedCount can trust every visible slot.
+    KeMemoryBarrier();
+    InterlockedIncrement(&g_KswordArkBugcheckShield.TimelineCommittedCount);
+}
+
+// Core buffer body shared by every callback entry point. Handles the
+// enable check, stall budget, timeline recording and bookkeeping so the
+// callback shims can stay a couple of lines each.
+static VOID
+KswordARKBugcheckShieldOnCallback(
+    _In_ ULONG Reason
+    )
+{
+    ULONG stallMs;
+    ULONG stageSeconds;
+
+    // The Executions counter guards against unload deregistering the
+    // record while a CPU is still inside this function.
+    InterlockedIncrement(&g_KswordArkBugcheckShield.Executions);
+    if (InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.Enabled,
+            0L,
+            0L) == 0L) {
+        // Disabled after registration; still record the reason so R3 can
+        // see a callback fired but no buffer was applied.
+        KswordARKBugcheckShieldRecordTimeline(Reason, 0UL);
+        InterlockedDecrement(&g_KswordArkBugcheckShield.Executions);
+        return;
+    }
+    // Flag the first-ever invocation for R3 UI feedback. The order matters:
+    // set Fired before consuming budget so a query racing the first hit
+    // never sees "budget consumed, Fired = 0".
+    InterlockedCompareExchange(&g_KswordArkBugcheckShield.Fired, 1L, 0L);
+    InterlockedIncrement(&g_KswordArkBugcheckShield.FireCount);
+    // Snapshot StageSeconds locally; the field itself is written only
+    // under ControlLock at PASSIVE_LEVEL so a plain read is safe here.
+    stageSeconds = g_KswordArkBugcheckShield.StageSeconds;
+    stallMs = KswordARKBugcheckShieldClaimStallBudgetMs(stageSeconds);
+    KswordARKBugcheckShieldStallMs(stallMs);
+    KswordARKBugcheckShieldRecordTimeline(Reason, stallMs);
+    InterlockedDecrement(&g_KswordArkBugcheckShield.Executions);
+}
+
+// Classic BugCheck callback: fires early during bug-check processing on the
+// crashing processor before dump generation.
+static VOID
+KswordARKBugcheckShieldClassicCallback(
+    _In_ PVOID Buffer,
+    _In_ ULONG Length
+    )
+{
+    // The buffer is our own ULONG scratch and is not used to communicate
+    // state back to Windows; acknowledge the parameters and drop into the
+    // shared body.
+    UNREFERENCED_PARAMETER(Buffer);
+    UNREFERENCED_PARAMETER(Length);
+    KswordARKBugcheckShieldOnCallback(
+        KSWORD_ARK_BUGCHECK_SHIELD_REASON_CLASSIC);
+}
+
+// Reason callback: fires for SECONDARY_DUMP_DATA, DUMP_IO and ADD_PAGES.
+// The Shield does not attempt to inject dump data or extra pages; we only
+// stall for the buffer budget and return to let Windows continue.
+static VOID
+KswordARKBugcheckShieldReasonCallback(
+    _In_ KBUGCHECK_CALLBACK_REASON Reason,
+    _In_ struct _KBUGCHECK_REASON_CALLBACK_RECORD* Record,
+    _In_ PVOID ReasonSpecificData,
+    _In_ ULONG ReasonSpecificDataLength
+    )
+{
+    ULONG reasonBit;
+
+    UNREFERENCED_PARAMETER(Record);
+    UNREFERENCED_PARAMETER(ReasonSpecificData);
+    UNREFERENCED_PARAMETER(ReasonSpecificDataLength);
+    // Map the kernel reason enum to the shared bitmask so R3 sees a
+    // single, wire-stable value even if Windows renumbers the enum.
+    switch (Reason) {
+    case KbCallbackSecondaryDumpData:
+        reasonBit = KSWORD_ARK_BUGCHECK_SHIELD_REASON_SECONDARY_DUMP_DATA;
+        break;
+    case KbCallbackDumpIo:
+        reasonBit = KSWORD_ARK_BUGCHECK_SHIELD_REASON_DUMP_IO;
+        break;
+    case KbCallbackAddPages:
+        reasonBit = KSWORD_ARK_BUGCHECK_SHIELD_REASON_ADD_PAGES;
+        break;
+    default:
+        // The Shield only registers the three reasons above; any other
+        // reason means the kernel invoked us for a callback we did not
+        // subscribe to. Record and exit without stalling.
+        reasonBit = 0UL;
+        break;
+    }
+    if (reasonBit == 0UL) {
+        // Skip the stall for reasons we did not request but still record
+        // the invocation so anomalies are visible in the timeline.
+        KswordARKBugcheckShieldRecordTimeline(0UL, 0UL);
+        return;
+    }
+    KswordARKBugcheckShieldOnCallback(reasonBit);
+}
+
+// Assemble the current state bitmap for R3 responses. Runs at PASSIVE_LEVEL
+// under ControlLock so registration state is a coherent snapshot.
+static ULONG
+KswordARKBugcheckShieldStateFlagsLocked(VOID)
+{
+    ULONG flags = 0UL;
+
+    if (InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.Enabled,
+            0L,
+            0L) != 0L) {
+        flags |= KSWORD_ARK_BUGCHECK_SHIELD_STATE_ACTIVE;
+    }
+    if (InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.Fired,
+            0L,
+            0L) != 0L) {
+        flags |= KSWORD_ARK_BUGCHECK_SHIELD_STATE_FIRED;
+    }
+    if (g_KswordArkBugcheckShield.ClassicRegistered) {
+        flags |= KSWORD_ARK_BUGCHECK_SHIELD_STATE_CLASSIC_REGISTERED;
+    }
+    if (g_KswordArkBugcheckShield.SecondaryRegistered) {
+        flags |= KSWORD_ARK_BUGCHECK_SHIELD_STATE_SECONDARY_REGISTERED;
+    }
+    if (g_KswordArkBugcheckShield.DumpIoRegistered) {
+        flags |= KSWORD_ARK_BUGCHECK_SHIELD_STATE_DUMPIO_REGISTERED;
+    }
+    if (g_KswordArkBugcheckShield.AddPagesRegistered) {
+        flags |= KSWORD_ARK_BUGCHECK_SHIELD_STATE_ADDPAGES_REGISTERED;
+    }
+    return flags;
+}
+
+// Deregister every previously registered callback record. Returns TRUE only
+// when all records were successfully deregistered; a FALSE return means at
+// least one callback was in flight and the caller must retry or refuse the
+// disable so we do not free the record while Windows is calling us.
+static BOOLEAN
+KswordARKBugcheckShieldDeregisterAllLocked(VOID)
+{
+    BOOLEAN allDeregistered = TRUE;
+
+    // Deregister the reason callbacks first so no additional executions
+    // can enter after Enabled is dropped.
+    if (g_KswordArkBugcheckShield.AddPagesRegistered) {
+        if (KeDeregisterBugCheckReasonCallback(
+                &g_KswordArkBugcheckShield.AddPagesRecord)) {
+            g_KswordArkBugcheckShield.AddPagesRegistered = FALSE;
+        }
+        else {
+            allDeregistered = FALSE;
+        }
+    }
+    if (g_KswordArkBugcheckShield.DumpIoRegistered) {
+        if (KeDeregisterBugCheckReasonCallback(
+                &g_KswordArkBugcheckShield.DumpIoRecord)) {
+            g_KswordArkBugcheckShield.DumpIoRegistered = FALSE;
+        }
+        else {
+            allDeregistered = FALSE;
+        }
+    }
+    if (g_KswordArkBugcheckShield.SecondaryRegistered) {
+        if (KeDeregisterBugCheckReasonCallback(
+                &g_KswordArkBugcheckShield.SecondaryRecord)) {
+            g_KswordArkBugcheckShield.SecondaryRegistered = FALSE;
+        }
+        else {
+            allDeregistered = FALSE;
+        }
+    }
+    if (g_KswordArkBugcheckShield.ClassicRegistered) {
+        if (KeDeregisterBugCheckCallback(
+                &g_KswordArkBugcheckShield.ClassicRecord)) {
+            g_KswordArkBugcheckShield.ClassicRegistered = FALSE;
+        }
+        else {
+            allDeregistered = FALSE;
+        }
+    }
+    return allDeregistered;
+}
+
+// Reset runtime accumulators back to their pre-enable defaults. Only called
+// after all callback records are deregistered.
+static VOID
+KswordARKBugcheckShieldResetRuntimeLocked(VOID)
+{
+    InterlockedExchange(&g_KswordArkBugcheckShield.Enabled, 0L);
+    InterlockedExchange(&g_KswordArkBugcheckShield.Fired, 0L);
+    InterlockedExchange(&g_KswordArkBugcheckShield.FireCount, 0L);
+    InterlockedExchange(&g_KswordArkBugcheckShield.TimelineNextIndex, 0L);
+    InterlockedExchange(&g_KswordArkBugcheckShield.TimelineCommittedCount, 0L);
+    InterlockedExchange(&g_KswordArkBugcheckShield.RemainingBudgetMs, 0L);
+    g_KswordArkBugcheckShield.ReasonMask = 0UL;
+    g_KswordArkBugcheckShield.StageSeconds = 0UL;
+    g_KswordArkBugcheckShield.TotalSeconds = 0UL;
+    // Zero the timeline ring so a subsequent enable presents a clean slate.
+    RtlZeroMemory(
+        g_KswordArkBugcheckShield.Timeline,
+        sizeof(g_KswordArkBugcheckShield.Timeline));
+}
+
+// Try to deregister every record and reset runtime state. Returns success
+// only when both the deregister and the drain succeed.
+static NTSTATUS
+KswordARKBugcheckShieldDisableLocked(VOID)
+{
+    // Flip Enabled off before touching the records so any concurrent
+    // callback observes the drop immediately and skips further stalls.
+    InterlockedExchange(&g_KswordArkBugcheckShield.Enabled, 0L);
+    if (!KswordARKBugcheckShieldDeregisterAllLocked()) {
+        // Restore Enabled=1 if any record could not be dropped; the driver
+        // has not actually disabled and must reflect that to R3.
+        InterlockedExchange(&g_KswordArkBugcheckShield.Enabled, 1L);
+        return STATUS_DEVICE_BUSY;
+    }
+    // The kernel deregister APIs synchronize with in-flight callbacks on
+    // the current CPU; verify Executions is 0 before publishing success.
+    if (InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.Executions,
+            0L,
+            0L) != 0L) {
+        return STATUS_DEVICE_BUSY;
+    }
+    KswordARKBugcheckShieldResetRuntimeLocked();
+    return STATUS_SUCCESS;
+}
+
+// Register a single reason callback. The caller flips the matching
+// registered flag in the state struct on success so the disable path
+// knows which records to undo.
+static NTSTATUS
+KswordARKBugcheckShieldRegisterReasonLocked(
+    _Inout_ PKBUGCHECK_REASON_CALLBACK_RECORD Record,
+    _In_ KBUGCHECK_CALLBACK_REASON Reason
+    )
+{
+    KeInitializeCallbackRecord(Record);
+    if (!KeRegisterBugCheckReasonCallback(
+            Record,
+            KswordARKBugcheckShieldReasonCallback,
+            Reason,
+            g_KswordArkBugcheckShieldComponent)) {
+        return STATUS_UNSUCCESSFUL;
+    }
+    return STATUS_SUCCESS;
+}
+
+// Register every requested reason atomically. If any registration fails we
+// roll back the ones that already succeeded so the driver never presents a
+// partial installation to Windows.
+static NTSTATUS
+KswordARKBugcheckShieldEnableLocked(
+    _In_ ULONG ReasonMask,
+    _In_ ULONG StageSeconds,
+    _In_ ULONG TotalSeconds
+    )
+{
+    NTSTATUS status = STATUS_SUCCESS;
+
+    // The enable path is only valid from a clean state. If a previous
+    // enable is still active or draining we reject the request instead of
+    // stacking registrations.
+    if (InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.Enabled,
+            0L,
+            0L) != 0L ||
+        g_KswordArkBugcheckShield.ClassicRegistered ||
+        g_KswordArkBugcheckShield.SecondaryRegistered ||
+        g_KswordArkBugcheckShield.DumpIoRegistered ||
+        g_KswordArkBugcheckShield.AddPagesRegistered) {
+        return STATUS_ALREADY_REGISTERED;
+    }
+    // Wipe accumulators so a re-enable presents a fresh timeline.
+    KswordARKBugcheckShieldResetRuntimeLocked();
+    g_KswordArkBugcheckShield.ReasonMask = ReasonMask;
+    g_KswordArkBugcheckShield.StageSeconds = StageSeconds;
+    g_KswordArkBugcheckShield.TotalSeconds = TotalSeconds;
+    // Seed the global remaining budget for this enable so callbacks share
+    // one bounded pool regardless of how many reasons were requested.
+    InterlockedExchange(
+        &g_KswordArkBugcheckShield.RemainingBudgetMs,
+        (LONG)(TotalSeconds * 1000UL));
+    if ((ReasonMask & KSWORD_ARK_BUGCHECK_SHIELD_REASON_CLASSIC) != 0UL) {
+        // Classic callbacks use the legacy KeRegisterBugCheckCallback entry;
+        // it is the earliest hook Windows offers to a driver during a bug
+        // check and has been stable since Windows XP.
+        KeInitializeCallbackRecord(&g_KswordArkBugcheckShield.ClassicRecord);
+        if (!KeRegisterBugCheckCallback(
+                &g_KswordArkBugcheckShield.ClassicRecord,
+                KswordARKBugcheckShieldClassicCallback,
+                &g_KswordArkBugcheckShield.ClassicBuffer,
+                sizeof(g_KswordArkBugcheckShield.ClassicBuffer),
+                g_KswordArkBugcheckShieldComponent)) {
+            status = STATUS_UNSUCCESSFUL;
+            goto Rollback;
+        }
+        g_KswordArkBugcheckShield.ClassicRegistered = TRUE;
+    }
+    if ((ReasonMask &
+            KSWORD_ARK_BUGCHECK_SHIELD_REASON_SECONDARY_DUMP_DATA) != 0UL) {
+        status = KswordARKBugcheckShieldRegisterReasonLocked(
+            &g_KswordArkBugcheckShield.SecondaryRecord,
+            KbCallbackSecondaryDumpData);
+        if (!NT_SUCCESS(status)) {
+            goto Rollback;
+        }
+        g_KswordArkBugcheckShield.SecondaryRegistered = TRUE;
+    }
+    if ((ReasonMask & KSWORD_ARK_BUGCHECK_SHIELD_REASON_DUMP_IO) != 0UL) {
+        status = KswordARKBugcheckShieldRegisterReasonLocked(
+            &g_KswordArkBugcheckShield.DumpIoRecord,
+            KbCallbackDumpIo);
+        if (!NT_SUCCESS(status)) {
+            goto Rollback;
+        }
+        g_KswordArkBugcheckShield.DumpIoRegistered = TRUE;
+    }
+    if ((ReasonMask & KSWORD_ARK_BUGCHECK_SHIELD_REASON_ADD_PAGES) != 0UL) {
+        // KbCallbackAddPages is supported from Windows 8; a failure here is
+        // still fatal to enable so R3 sees an explicit reject rather than
+        // a silently degraded set of registrations.
+        status = KswordARKBugcheckShieldRegisterReasonLocked(
+            &g_KswordArkBugcheckShield.AddPagesRecord,
+            KbCallbackAddPages);
+        if (!NT_SUCCESS(status)) {
+            goto Rollback;
+        }
+        g_KswordArkBugcheckShield.AddPagesRegistered = TRUE;
+    }
+    // Publish Enabled last so a callback that fires the moment the final
+    // record was registered still observes a fully installed Shield.
+    InterlockedExchange(&g_KswordArkBugcheckShield.Enabled, 1L);
+    return STATUS_SUCCESS;
+
+Rollback:
+    // Roll back every record that did register; the drain path is safe to
+    // reuse because we never set Enabled=1 on this attempt.
+    (VOID)KswordARKBugcheckShieldDeregisterAllLocked();
+    KswordARKBugcheckShieldResetRuntimeLocked();
+    return status;
+}
+
+// Validate the fixed-length request. Returns TRUE only when every field is
+// well formed for the current protocol version. The caller guarantees the
+// pointer is non-null because WdfRequestRetrieveInputBuffer succeeded.
+static BOOLEAN
+KswordARKBugcheckShieldRequestValid(
+    _In_ const KSWORD_ARK_BUGCHECK_SHIELD_REQUEST* Request
+    )
+{
+    if (Request->size != sizeof(*Request) ||
+        Request->version != KSWORD_ARK_BUGCHECK_SHIELD_PROTOCOL_VERSION) {
+        return FALSE;
+    }
+    // Reserved fields exist so future versions can repurpose them; refuse
+    // any non-zero value so a v1 driver never accidentally interprets v2
+    // request extensions as valid data.
+    if (Request->reserved0 != 0UL || Request->reserved1 != 0UL) {
+        return FALSE;
+    }
+    // Only the confirmed flag is defined today; reject unknown bits.
+    if ((Request->flags & ~KSWORD_ARK_BUGCHECK_SHIELD_FLAG_UI_CONFIRMED) !=
+            0UL) {
+        return FALSE;
+    }
+    // Any of the three actions is acceptable.
+    if (Request->action != KSWORD_ARK_BUGCHECK_SHIELD_ACTION_QUERY &&
+        Request->action != KSWORD_ARK_BUGCHECK_SHIELD_ACTION_ENABLE &&
+        Request->action != KSWORD_ARK_BUGCHECK_SHIELD_ACTION_DISABLE) {
+        return FALSE;
+    }
+    return TRUE;
+}
+
+// Fill the fixed-length response, including the currently visible slice of
+// the timeline ring.
+static VOID
+KswordARKBugcheckShieldFillResponseLocked(
+    _Out_ KSWORD_ARK_BUGCHECK_SHIELD_RESPONSE* Response,
+    _In_ ULONG ProtocolStatus
+    )
+{
+    LONG committed;
+    LONG index;
+
+    // Zero the response first so failure paths never leak stale kernel
+    // stack data back to R3.
+    RtlZeroMemory(Response, sizeof(*Response));
+    Response->size = sizeof(*Response);
+    Response->version = KSWORD_ARK_BUGCHECK_SHIELD_PROTOCOL_VERSION;
+    Response->status = ProtocolStatus;
+    Response->stateFlags = KswordARKBugcheckShieldStateFlagsLocked();
+    Response->reasonMask = g_KswordArkBugcheckShield.ReasonMask;
+    Response->stageSeconds = g_KswordArkBugcheckShield.StageSeconds;
+    Response->totalSeconds = g_KswordArkBugcheckShield.TotalSeconds;
+    Response->fireCount = (ULONG)InterlockedCompareExchange(
+        &g_KswordArkBugcheckShield.FireCount, 0L, 0L);
+    committed = InterlockedCompareExchange(
+        &g_KswordArkBugcheckShield.TimelineCommittedCount, 0L, 0L);
+    if (committed < 0L) {
+        committed = 0L;
+    }
+    if ((ULONG)committed > KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRIES) {
+        committed = (LONG)KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRIES;
+    }
+    Response->timelineCount = (ULONG)committed;
+    Response->lastStatus = (LONG)g_KswordArkBugcheckShield.LastStatus;
+    // Copy the committed prefix; the remainder was already zeroed above.
+    for (index = 0; index < committed; ++index) {
+        Response->timeline[index] =
+            g_KswordArkBugcheckShield.Timeline[index];
+    }
+}
+
+// Public initialization entry called from DriverEntry. It only prepares the
+// synchronization primitives; no callback is registered until an IOCTL
+// arrives with an explicit enable request.
+VOID
+KswordARKBugcheckShieldInitialize(
+    VOID
+    )
+{
+#if !KSWORD_ARK_BUGCHECK_DIAGNOSTICS_ENABLED
+    // Diagnostics disabled at compile time: nothing to do.
+    return;
+#else
+    // Zero the state so a fresh driver load starts with an inactive Shield.
+    RtlZeroMemory(
+        &g_KswordArkBugcheckShield,
+        sizeof(g_KswordArkBugcheckShield));
+    ExInitializeFastMutex(&g_KswordArkBugcheckShield.ControlLock);
+    g_KswordArkBugcheckShield.LastStatus = STATUS_SUCCESS;
+#endif
+}
+
+// Public uninitialize entry. Called from EvtDriverUnload after the control
+// device becomes invisible to user space, so no additional IOCTLs can race.
+VOID
+KswordARKBugcheckShieldUninitialize(
+    VOID
+    )
+{
+#if !KSWORD_ARK_BUGCHECK_DIAGNOSTICS_ENABLED
+    return;
+#else
+    NTSTATUS status;
+
+    // ControlLock is the same one the IOCTL path uses; acquiring it here
+    // guarantees the disable path serializes with any final query racing
+    // driver unload from user space.
+    ExAcquireFastMutex(&g_KswordArkBugcheckShield.ControlLock);
+    status = KswordARKBugcheckShieldDisableLocked();
+    g_KswordArkBugcheckShield.LastStatus = status;
+    ExReleaseFastMutex(&g_KswordArkBugcheckShield.ControlLock);
+#endif
+}
+
+// IOCTL configure entry point registered in ioctl_registry.c. All input and
+// output are fixed-length METHOD_BUFFERED packets, so buffer retrieval and
+// bounds checks are trivial and never dereference user-mode pointers
+// directly.
+NTSTATUS
+KswordARKBugcheckShieldIoctlConfigure(
+    _In_ WDFDEVICE Device,
+    _In_ WDFREQUEST Request,
+    _In_ size_t InputBufferLength,
+    _In_ size_t OutputBufferLength,
+    _Out_ size_t* BytesReturned
+    )
+{
+#if !KSWORD_ARK_BUGCHECK_DIAGNOSTICS_ENABLED
+    // Fail closed when the entire diagnostics stack is disabled.
+    UNREFERENCED_PARAMETER(Device);
+    UNREFERENCED_PARAMETER(Request);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    if (BytesReturned != NULL) {
+        *BytesReturned = 0U;
+    }
+    return STATUS_NOT_SUPPORTED;
+#else
+    KSWORD_ARK_BUGCHECK_SHIELD_REQUEST* input = NULL;
+    KSWORD_ARK_BUGCHECK_SHIELD_RESPONSE* output = NULL;
+    NTSTATUS status;
+    ULONG protocolStatus = KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INVALID_REQUEST;
+    ULONG stageSeconds;
+    ULONG totalSeconds;
+
+    UNREFERENCED_PARAMETER(Device);
+
+    if (BytesReturned == NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    *BytesReturned = 0U;
+    // Retrieve the fixed-length input buffer; the framework handles all
+    // copy-in and access-mode checks for METHOD_BUFFERED.
+    status = WdfRequestRetrieveInputBuffer(
+        Request,
+        sizeof(*input),
+        (PVOID*)&input,
+        NULL);
+    if (!NT_SUCCESS(status) || InputBufferLength < sizeof(*input)) {
+        return NT_SUCCESS(status) ? STATUS_BUFFER_TOO_SMALL : status;
+    }
+    // Retrieve the fixed-length output buffer; refusing here keeps the
+    // response layout stable and unambiguous for R3.
+    status = WdfRequestRetrieveOutputBuffer(
+        Request,
+        sizeof(*output),
+        (PVOID*)&output,
+        NULL);
+    if (!NT_SUCCESS(status) || OutputBufferLength < sizeof(*output)) {
+        return NT_SUCCESS(status) ? STATUS_BUFFER_TOO_SMALL : status;
+    }
+
+    // Serialize the transition. All state mutation happens under this lock
+    // so a concurrent query cannot observe a torn snapshot.
+    ExAcquireFastMutex(&g_KswordArkBugcheckShield.ControlLock);
+    if (!KswordARKBugcheckShieldRequestValid(input)) {
+        // Bad header: fail closed and expose the last kernel status so R3
+        // can render a precise reason.
+        g_KswordArkBugcheckShield.LastStatus = STATUS_INVALID_PARAMETER;
+        protocolStatus = KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INVALID_REQUEST;
+    }
+    else if (input->action == KSWORD_ARK_BUGCHECK_SHIELD_ACTION_QUERY) {
+        // Query is idempotent and never touches the callback state.
+        protocolStatus = InterlockedCompareExchange(
+            &g_KswordArkBugcheckShield.Enabled,
+            0L,
+            0L) != 0L
+            ? KSWORD_ARK_BUGCHECK_SHIELD_STATUS_ACTIVE
+            : KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INACTIVE;
+    }
+    else if (input->action == KSWORD_ARK_BUGCHECK_SHIELD_ACTION_DISABLE) {
+        // Attempt to deregister every callback; the drain path may report
+        // BUSY if a callback is still executing on another CPU.
+        status = KswordARKBugcheckShieldDisableLocked();
+        g_KswordArkBugcheckShield.LastStatus = status;
+        protocolStatus = NT_SUCCESS(status)
+            ? KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INACTIVE
+            : KSWORD_ARK_BUGCHECK_SHIELD_STATUS_BUSY;
+    }
+    else if (input->action == KSWORD_ARK_BUGCHECK_SHIELD_ACTION_ENABLE) {
+        if ((input->flags &
+                KSWORD_ARK_BUGCHECK_SHIELD_FLAG_UI_CONFIRMED) == 0UL ||
+            input->confirmationToken !=
+                KSWORD_ARK_BUGCHECK_SHIELD_CONFIRMATION_TOKEN) {
+            // Enable requires the explicit UI-side confirmation contract.
+            g_KswordArkBugcheckShield.LastStatus = STATUS_ACCESS_DENIED;
+            protocolStatus =
+                KSWORD_ARK_BUGCHECK_SHIELD_STATUS_CONFIRMATION_NEEDED;
+        }
+        else if ((input->reasonMask &
+                    ~KSWORD_ARK_BUGCHECK_SHIELD_REASON_ALL) != 0UL ||
+                 input->reasonMask == 0UL) {
+            // Reason mask must select at least one supported reason and
+            // must not include unknown bits.
+            g_KswordArkBugcheckShield.LastStatus = STATUS_INVALID_PARAMETER;
+            protocolStatus =
+                KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INVALID_REQUEST;
+        }
+        else {
+            // Apply defaults for zero values so R3 can send a minimal
+            // request; then clamp both knobs to the shared caps.
+            stageSeconds = input->stageSeconds == 0UL
+                ? KSWORD_ARK_BUGCHECK_SHIELD_DEFAULT_STAGE_SECONDS
+                : input->stageSeconds;
+            totalSeconds = input->totalSeconds == 0UL
+                ? KSWORD_ARK_BUGCHECK_SHIELD_DEFAULT_TOTAL_SECONDS
+                : input->totalSeconds;
+            if (stageSeconds >
+                    KSWORD_ARK_BUGCHECK_SHIELD_STAGE_MAX_SECONDS) {
+                stageSeconds =
+                    KSWORD_ARK_BUGCHECK_SHIELD_STAGE_MAX_SECONDS;
+            }
+            if (totalSeconds >
+                    KSWORD_ARK_BUGCHECK_SHIELD_TOTAL_MAX_SECONDS) {
+                totalSeconds =
+                    KSWORD_ARK_BUGCHECK_SHIELD_TOTAL_MAX_SECONDS;
+            }
+            // Enforce total >= stage so at least one full stage fits.
+            if (stageSeconds > totalSeconds) {
+                stageSeconds = totalSeconds;
+            }
+            status = KswordARKBugcheckShieldEnableLocked(
+                input->reasonMask,
+                stageSeconds,
+                totalSeconds);
+            g_KswordArkBugcheckShield.LastStatus = status;
+            if (status == STATUS_SUCCESS) {
+                protocolStatus = KSWORD_ARK_BUGCHECK_SHIELD_STATUS_ACTIVE;
+            }
+            else if (status == STATUS_ALREADY_REGISTERED) {
+                protocolStatus = KSWORD_ARK_BUGCHECK_SHIELD_STATUS_ACTIVE;
+            }
+            else if (status == STATUS_NOT_SUPPORTED) {
+                protocolStatus =
+                    KSWORD_ARK_BUGCHECK_SHIELD_STATUS_UNSUPPORTED;
+            }
+            else {
+                protocolStatus =
+                    KSWORD_ARK_BUGCHECK_SHIELD_STATUS_REGISTRATION_FAILED;
+            }
+        }
+    }
+
+    // Serialize the response snapshot under the same lock so state and
+    // timeline agree with each other for this reply.
+    KswordARKBugcheckShieldFillResponseLocked(output, protocolStatus);
+    ExReleaseFastMutex(&g_KswordArkBugcheckShield.ControlLock);
+    *BytesReturned = sizeof(*output);
+    return STATUS_SUCCESS;
+#endif
+}

--- a/KswordARKDriver/src/framework/driver_entry.c
+++ b/KswordARKDriver/src/framework/driver_entry.c
@@ -249,6 +249,11 @@ Return Value:
     }
     // Guard 仍是独立的一次性调试能力；初始化本身不会安装 KeBugCheckEx hook。
     KswordARKBugcheckGuardInitialize();
+    // Shield 只准备同步原语，不注册任何 BugCheck 回调；R3 通过 IOCTL 显式启用。
+    KswordARKBugcheckShieldInitialize();
+    // Anti-BSOD 参考实现只准备同步原语；编译开关默认关闭，即使打开也需要 R3
+    // 携带 UI 确认令牌才会走 Install 流程，且签名表为空时会 fail-closed。
+    KswordARKAntiBsodInitialize();
 #else
     // Fail closed while the crash-time renderer and guard are disabled.
     TraceEvents(
@@ -315,8 +320,10 @@ Return Value:
     KswordARKDriverResetDirectoryScanCache();
 
 #if KSWORD_ARK_BUGCHECK_DIAGNOSTICS_ENABLED
-    // 先还原一次性 Guard，再由控制器撤销按需安装的 BGP 回调和预生成资源。
+    // 先还原一次性 Guard、Shield 与 Anti-BSOD 参考路径，再撤销 BGP 资源。
     KswordARKBugcheckGuardUninitialize();
+    KswordARKBugcheckShieldUninitialize();
+    KswordARKAntiBsodUninitialize();
     KswordARKBugcheckControlUninitialize();
 #endif
 

--- a/shared/driver/KswordArkBugcheckIoctl.h
+++ b/shared/driver/KswordArkBugcheckIoctl.h
@@ -240,3 +240,269 @@ typedef struct _KSWORD_ARK_BUGCHECK_GUARD_RESPONSE
     unsigned char originalBytes[KSWORD_ARK_BUGCHECK_GUARD_HOOK_BYTES];
     unsigned char hookBytes[KSWORD_ARK_BUGCHECK_GUARD_HOOK_BYTES];
 } KSWORD_ARK_BUGCHECK_GUARD_RESPONSE;
+
+// Bugcheck Shield: PatchGuard-safe multi-stage bugcheck buffer.
+//
+// The Shield is an alternative buffer backend inspired by publicly circulated
+// reverse-engineering notes on private-slot bugcheck-suppression drivers.
+// Those samples hook undocumented ntoskrnl function-pointer slots and wait
+// forever on unsignaled events; that design fails Windows integrity checks
+// and cannot be presented as a supported feature. The Shield instead uses
+// only documented KeRegisterBugCheckCallback / KeRegisterBugCheckReasonCallback
+// entry points. PatchGuard has no visibility into these APIs, so the Shield
+// is guaranteed to leave the kernel image untouched.
+//
+// The Shield stages a bounded delay across up to four reason callbacks so
+// external observers (screenshot capture, out-of-band logging, remote
+// telemetry) receive a longer window before the actual reboot. It never
+// modifies private kernel state, never suppresses the underlying bugcheck,
+// and always yields control back to Windows so a normal dump can be written.
+#define KSWORD_ARK_BUGCHECK_SHIELD_PROTOCOL_VERSION 1UL
+#define KSWORD_ARK_IOCTL_FUNCTION_CONFIGURE_BUGCHECK_SHIELD 0x8FEUL
+
+#define IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD \
+    CTL_CODE( \
+        KSWORD_ARK_IOCTL_DEVICE_TYPE, \
+        KSWORD_ARK_IOCTL_FUNCTION_CONFIGURE_BUGCHECK_SHIELD, \
+        METHOD_BUFFERED, \
+        FILE_WRITE_ACCESS)
+
+// Fixed-length action set. QUERY inspects state without altering it; ENABLE
+// registers all requested reason callbacks; DISABLE deregisters everything
+// and drains any in-flight callback invocations before returning.
+#define KSWORD_ARK_BUGCHECK_SHIELD_ACTION_QUERY   0UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_ACTION_ENABLE  1UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_ACTION_DISABLE 2UL
+
+// Enabling the Shield requires an explicit UI confirmation flag plus a
+// well-known token, mirroring the KSword guard contract. This prevents an
+// accidental or headless enable from installing crash-time callbacks.
+#define KSWORD_ARK_BUGCHECK_SHIELD_FLAG_UI_CONFIRMED  0x00000001UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_CONFIRMATION_TOKEN 0x4C48534BUL /* 'KSHL' */
+
+// Callback reason bitmask. R3 selects which reasons to register; every
+// selected reason must succeed or the enable fails atomically.
+#define KSWORD_ARK_BUGCHECK_SHIELD_REASON_CLASSIC              0x00000001UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_REASON_SECONDARY_DUMP_DATA  0x00000002UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_REASON_DUMP_IO              0x00000004UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_REASON_ADD_PAGES            0x00000008UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_REASON_ALL \
+    (KSWORD_ARK_BUGCHECK_SHIELD_REASON_CLASSIC | \
+     KSWORD_ARK_BUGCHECK_SHIELD_REASON_SECONDARY_DUMP_DATA | \
+     KSWORD_ARK_BUGCHECK_SHIELD_REASON_DUMP_IO | \
+     KSWORD_ARK_BUGCHECK_SHIELD_REASON_ADD_PAGES)
+
+// Buffer budgets. Each active callback contributes up to per-stage seconds
+// of stall; the total is capped so a slow storage stack or watchdog cannot
+// be starved. Values are validated in the driver and clamped as required.
+#define KSWORD_ARK_BUGCHECK_SHIELD_STAGE_MIN_SECONDS  0UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STAGE_MAX_SECONDS  8UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_TOTAL_MAX_SECONDS  16UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_DEFAULT_STAGE_SECONDS 3UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_DEFAULT_TOTAL_SECONDS 10UL
+
+// Status codes returned to R3. INACTIVE and ACTIVE describe the primary
+// mode; the remaining values describe why an enable was refused.
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_OK                  0UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INACTIVE            1UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_ACTIVE              2UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_CONFIRMATION_NEEDED 3UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_UNSUPPORTED         4UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_BUSY                5UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_REGISTRATION_FAILED 6UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATUS_INVALID_REQUEST     7UL
+
+// State flag bitmap: mirrors what the Shield has actually installed.
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATE_ACTIVE                0x00000001UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATE_FIRED                 0x00000002UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATE_CLASSIC_REGISTERED    0x00000004UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATE_SECONDARY_REGISTERED  0x00000008UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATE_DUMPIO_REGISTERED     0x00000010UL
+#define KSWORD_ARK_BUGCHECK_SHIELD_STATE_ADDPAGES_REGISTERED   0x00000020UL
+
+// Bounded timeline reported back to R3. Each callback records reason id,
+// bug-check code, CPU and 100ns duration. The ring is intentionally small
+// and only committed after the callback returns.
+#define KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRIES 16UL
+
+typedef struct _KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRY
+{
+    unsigned long reason;
+    unsigned long bugcheckCode;
+    unsigned long cpu;
+    unsigned long stalledMilliseconds;
+} KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRY;
+
+// Request layout. Fields default to 0; ENABLE fills reasonMask plus stage
+// and total seconds. Reserved fields must be zero and are rejected otherwise
+// so future versions can safely repurpose them.
+typedef struct _KSWORD_ARK_BUGCHECK_SHIELD_REQUEST
+{
+    unsigned long size;
+    unsigned long version;
+    unsigned long action;
+    unsigned long flags;
+    unsigned long confirmationToken;
+    unsigned long reasonMask;
+    unsigned long stageSeconds;
+    unsigned long totalSeconds;
+    unsigned long reserved0;
+    unsigned long reserved1;
+} KSWORD_ARK_BUGCHECK_SHIELD_REQUEST;
+
+// Response layout. The Shield never returns raw kernel pointers.
+typedef struct _KSWORD_ARK_BUGCHECK_SHIELD_RESPONSE
+{
+    unsigned long size;
+    unsigned long version;
+    unsigned long status;
+    unsigned long stateFlags;
+    unsigned long reasonMask;
+    unsigned long stageSeconds;
+    unsigned long totalSeconds;
+    unsigned long fireCount;
+    unsigned long timelineCount;
+    long lastStatus;
+    unsigned long reserved0;
+    unsigned long reserved1;
+    KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRY timeline
+        [KSWORD_ARK_BUGCHECK_SHIELD_TIMELINE_ENTRIES];
+} KSWORD_ARK_BUGCHECK_SHIELD_RESPONSE;
+
+// Anti-BSOD reference implementation.
+//
+// This IOCTL exposes a faithful, algorithm-level reproduction of the
+// Disable-PatchGuard-BSOD.sys pattern described in the Anti-BSOD IDA
+// analysis: five per-build signature profiles, nine signature slots per
+// profile, module enumeration to locate ntoskrnl .text, stack-origin
+// classification, IPI-based per-CPU state capture, and two hooks that
+// overwrite undocumented ntoskrnl function-pointer slots.
+//
+// Every signature pattern in the driver ships zeroed with length=0 so the
+// wildcard scanner returns 0 for every match attempt and the Install
+// path fail-closes before any private ntoskrnl write. The reference
+// module is gated behind a compile flag that is OFF by default and is
+// not wired into shipping DriverEntry initialization. Populating real
+// signatures makes the driver trip PatchGuard/HVCI on modern Windows and
+// leaves the kernel in a corrupt state after the suppression path runs;
+// this is documented behavior of the sample and does not change.
+#define KSWORD_ARK_ANTIBSOD_PROTOCOL_VERSION 1UL
+#define KSWORD_ARK_IOCTL_FUNCTION_CONFIGURE_ANTIBSOD 0x8FFUL
+
+#define IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD \
+    CTL_CODE( \
+        KSWORD_ARK_IOCTL_DEVICE_TYPE, \
+        KSWORD_ARK_IOCTL_FUNCTION_CONFIGURE_ANTIBSOD, \
+        METHOD_BUFFERED, \
+        FILE_WRITE_ACCESS)
+
+// Fixed action set: query state, install the hooks (fail-closed when the
+// signature table is empty), or uninstall by restoring the saved slot
+// contents and deregistering any per-CPU tracking. The reference does not
+// expose a "load signatures" IOCTL: that step is deliberately manual.
+// PROBE runs the whole scan pipeline read-only so R3 can render which rule
+// hit and which missed, without ever writing an ntoskrnl private slot.
+#define KSWORD_ARK_ANTIBSOD_ACTION_QUERY     0UL
+#define KSWORD_ARK_ANTIBSOD_ACTION_INSTALL   1UL
+#define KSWORD_ARK_ANTIBSOD_ACTION_UNINSTALL 2UL
+#define KSWORD_ARK_ANTIBSOD_ACTION_PROBE     3UL
+
+// Slot indices used by slotExpectedMask / slotHitMask. Each bit N in
+// those masks corresponds to slot N below. Bit width fits in a ULONG so
+// R3 rendering can iterate a 9-entry table without a wider descriptor.
+#define KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_ANCHOR         0UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_CODE_START     1UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_BUGCHECK_CODE_END       2UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_STATE_FLAG_PTR          3UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_KPCR_STATE_OFFSET       4UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_KPCR_SECONDARY_OFFSET   5UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_INPROGRESS_FLAG_PTR     6UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_ALL_HOOK_SLOT           7UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_CURRENT_HOOK_SLOT       8UL
+#define KSWORD_ARK_ANTIBSOD_SLOT_COUNT                   9UL
+
+// Support-summary values reported to R3.
+//   UNKNOWN: no probe has run yet on this driver load.
+//   UNSUPPORTED_BUILD: current Windows build is outside every profile.
+//   SIGNATURES_EMPTY: build recognized, but signature table is not
+//     populated in the driver image; every scan therefore returns 0.
+//   PARTIAL_MATCH: some scans resolved, some did not. The Install path
+//     will fail-close in this state.
+//   FULL_MATCH: every scan resolved. This is the state Install commits.
+#define KSWORD_ARK_ANTIBSOD_SUPPORT_UNKNOWN            0UL
+#define KSWORD_ARK_ANTIBSOD_SUPPORT_UNSUPPORTED_BUILD  1UL
+#define KSWORD_ARK_ANTIBSOD_SUPPORT_SIGNATURES_EMPTY   2UL
+#define KSWORD_ARK_ANTIBSOD_SUPPORT_PARTIAL_MATCH      3UL
+#define KSWORD_ARK_ANTIBSOD_SUPPORT_FULL_MATCH         4UL
+
+#define KSWORD_ARK_ANTIBSOD_FLAG_UI_CONFIRMED  0x00000001UL
+#define KSWORD_ARK_ANTIBSOD_CONFIRMATION_TOKEN 0x424B414BUL /* 'KAKB' */
+
+#define KSWORD_ARK_ANTIBSOD_STATUS_OK                    0UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_INACTIVE              1UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_ACTIVE                2UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_CONFIRMATION_NEEDED   3UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_UNSUPPORTED           4UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_INVALID_REQUEST       5UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_BUSY                  6UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_PROFILE_MISSING       7UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_MODULE_NOT_FOUND      8UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_SIGNATURE_NOT_FOUND   9UL
+#define KSWORD_ARK_ANTIBSOD_STATUS_HOOK_INSTALL_FAILED  10UL
+
+// State bitmap. Each bit is either the reproduction of the sample's own
+// state machine or an explicit KSword-side safety flag noted by the
+// analysis report.
+#define KSWORD_ARK_ANTIBSOD_STATE_INSTALLED               0x00000001UL
+#define KSWORD_ARK_ANTIBSOD_STATE_HOOKS_ACTIVE            0x00000002UL
+#define KSWORD_ARK_ANTIBSOD_STATE_LEGACY_BUILD            0x00000004UL
+#define KSWORD_ARK_ANTIBSOD_STATE_PROFILE_SELECTED        0x00000008UL
+#define KSWORD_ARK_ANTIBSOD_STATE_MODULE_RANGE_RESOLVED   0x00000010UL
+#define KSWORD_ARK_ANTIBSOD_STATE_TARGETS_RESOLVED        0x00000020UL
+#define KSWORD_ARK_ANTIBSOD_STATE_PER_CPU_STATE_CAPTURED  0x00000040UL
+#define KSWORD_ARK_ANTIBSOD_STATE_SIGNATURES_EMPTY        0x00000080UL
+
+// Fixed-length request. The reference implementation intentionally does
+// not accept a signature payload through this IOCTL: publishing wire
+// signatures for private ntoskrnl slots is outside the scope of the
+// analysis report and is not a shape the KSword driver ships.
+typedef struct _KSWORD_ARK_ANTIBSOD_REQUEST
+{
+    unsigned long size;
+    unsigned long version;
+    unsigned long action;
+    unsigned long flags;
+    unsigned long confirmationToken;
+    unsigned long reserved0;
+    unsigned long reserved1;
+    unsigned long reserved2;
+} KSWORD_ARK_ANTIBSOD_REQUEST;
+
+// Fixed-length response. The response reports which stage of the install
+// pipeline reached completion, but never returns raw kernel pointers.
+//
+// slotExpectedMask and slotHitMask are the per-rule transparency channel:
+//   - Bit N in slotExpectedMask is set when slot N in the selected
+//     profile has a nonzero Length. This tells R3 "the operator has
+//     supplied signature bytes for this rule."
+//   - Bit N in slotHitMask is set when the scan for slot N resolved to
+//     a nonzero address. This tells R3 "the rule matched on this exact
+//     kernel image."
+// Masks are only meaningful after INSTALL or PROBE has run this boot.
+typedef struct _KSWORD_ARK_ANTIBSOD_RESPONSE
+{
+    unsigned long size;
+    unsigned long version;
+    unsigned long status;
+    unsigned long stateFlags;
+    unsigned long windowsBuildNumber;
+    unsigned long selectedProfileIndex;
+    unsigned long kthreadRoutineOffset;
+    unsigned long activeProcessorCount;
+    unsigned long hookInvocationCount;
+    long lastStatus;
+    unsigned long slotExpectedMask;
+    unsigned long slotHitMask;
+    unsigned long supportSummary;
+    unsigned long reserved0;
+} KSWORD_ARK_ANTIBSOD_RESPONSE;


### PR DESCRIPTION
## Summary

Two new bugcheck submodules under `KswordARKDriver/src/features/bugcheck/`.

### Shield (`bugcheck_shield.c`) — PatchGuard-safe buffer backend

- Uses only documented `KeRegisterBugCheckCallback` +
  `KeRegisterBugCheckReasonCallback` (SecondaryDumpData / DumpIo / AddPages).
- Bounded per-stage stall (<=8s) with a shared total budget (<=16s) via CAS
  on `RemainingBudgetMs`. Yields back to Windows so the normal dump path runs.
- Fixed-size 16-entry timeline ring publishes which reason fired and how long
  each stalled; readable through a QUERY IOCTL.
- Enable requires the `KSHL` token plus `UI_CONFIRMED` flag. Disable drains
  an `Executions` counter before deregistering the four records.
- Never patches KeBugCheckEx, never touches any private ntoskrnl state.
- IOCTL: `0x8FE` `IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD`.

### Anti-BSOD (`bugcheck_antibsod.c`) — sample reference implementation

Algorithm-level reproduction of the `Disable-PatchGuard-BSOD.sys` sample
from the Anti-BSOD IDA analysis. Kept as a **research reference**, not a
shipping feature.

- Five build profiles (7601 / 9600 / 20348 / 26200 / 28000) with the
  reported KTHREAD offsets (912 / 1528 / 1104 / 1248 / 1248).
- Nine-slot 0x4E0-byte profile layout with `C_ASSERT`s (ADD 0x88, RIP 0x8C,
  READ 0x88). Wildcard byte scanner, RIP-relative resolver, module range
  via `ZwQuerySystemInformation`, PE header walk, 64-frame
  `RtlCaptureStackBackTrace` classifier, IPI per-CPU capture, two hooks.
- Gated behind `KSWORD_ARK_ANTIBSOD_REFERENCE_ENABLED` (default **0**).
  When off, entry points return `STATUS_NOT_SUPPORTED` and no code paths
  execute.
- Signatures ship zeroed. `FindWildcardBytePattern(Length=0)` returns 0,
  so every scan returns 0 and Install fail-closes with
  `STATUS_OBJECT_NAME_NOT_FOUND` before any private slot write.
- Adds the three fail-closed checks the report calls out as missing from
  the sample: build > 28000 rejected, all resolved targets non-zero
  checked, SEH around slot writes with rollback.
- IOCTL: `0x8FF` `IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD` with
  QUERY / PROBE / INSTALL / UNINSTALL actions. PROBE runs the whole scan
  pipeline read-only and publishes:
  - `slotExpectedMask` (9 bits): which slots have operator-supplied signature bytes
  - `slotHitMask` (9 bits): which slots resolved to nonzero on this kernel image
  - `supportSummary`: UNKNOWN / UNSUPPORTED_BUILD / SIGNATURES_EMPTY /
    PARTIAL_MATCH / FULL_MATCH

### Wiring

- `shared/driver/KswordArkBugcheckIoctl.h`: added Shield (`0x8FE`) and
  Anti-BSOD (`0x8FF`) IOCTL protocols with fixed-length request/response.
- `KswordARKDriver/include/ark/ark_bugcheck.h`: prototypes.
- `KswordARKDriver/src/framework/driver_entry.c`: Initialize after Guard,
  Uninitialize before ControlUninitialize, both under existing
  `KSWORD_ARK_BUGCHECK_DIAGNOSTICS_ENABLED` gate.
- `KswordARKDriver/src/dispatch/ioctl_registry.c`: forward decls +
  registry entries.
- `KswordARKDriver.vcxproj` and `.vcxproj.filters`: new ClCompile
  entries under `Source Files\Features\Bugcheck`.
- `.claude/memory/ksword-bugcheck-shield.md` and
  `.claude/memory/ksword-bugcheck-antibsod.md`: cross-agent shared memory
  covering scope, boundaries, transparency mask semantics, and complementarity
  with the existing Guard / BGP renderer paths. Index entries added to
  `.claude/memory/MEMORY.md`.

## Testing

- **Not yet built.** The changes were authored on macOS; the Windows build
  host still needs to run `$env:USERPROFILE\.codex\skills\ksword-build-check\scripts\Invoke-KSwordBuildCheck.ps1`
  to confirm zero warnings under `/WX`.
- Static review performed: Shield and Anti-BSOD both match the KSword driver
  convention (dynamic `ExAllocatePool2` resolve with `NonPagedPoolNx`
  fallback under pragma-suppressed 4996, `FAST_MUTEX` control lock only
  at PASSIVE_LEVEL, atomic state via `InterlockedCompareExchange` on
  `volatile LONG`).
- Anti-BSOD implementation cross-checked line-by-line against the report's
  decompiled C++ and the analysis boundary table. Deviations are limited to
  the three fail-closed hardenings the report itself identifies as missing
  from the original sample.
- Default runtime effect (compile flag off, signatures empty):
  `IOCTL_KSWORD_ARK_CONFIGURE_ANTIBSOD` returns `STATUS_NOT_SUPPORTED`;
  `IOCTL_KSWORD_ARK_CONFIGURE_BUGCHECK_SHIELD` returns INACTIVE. No
  ntoskrnl code, private state, MSR, CR8, SSDT, IDT or GDT is ever
  touched by these modules.

## Boundaries

- Shield is intended as a shipping capability (PatchGuard / HVCI safe).
- Anti-BSOD is intentionally not shippable: even with the compile flag on,
  the empty signature table prevents any private-slot write, and populating
  signatures manually would run into PatchGuard `0x109` / HVCI on any
  modern configured Windows machine. The module exists so an operator can
  inspect the sample's algorithm inside a controlled research environment
  and observe which of the 9 rules would match on a given kernel image
  without ever committing hooks.
- Neither module changes shipping DriverEntry behavior on machines that
  do not explicitly request enable through the corresponding IOCTL.